### PR TITLE
Set the right permissions for robin home dir.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && apt-get update \
     && apt-get install -y sudo \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
-    && chmod 0440 /etc/sudoers.d/$USERNAME
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    && chown $USERNAME /home/$USERNAME
 
 # ********************************************************
 # * Anything else you want to do like clean up goes here *


### PR DESCRIPTION
When creating the devcontainer image with Visual Studio Code the following log is generated:
```
[3296 ms] Start: Run in container:  (command -v getent >/dev/null 2>&1 && getent passwd 'robin' || grep -E '^robin|^[^:]*:[^:]*:robin:' /etc/passwd || true)
[3296 ms] Start: Updating configuration state
[3300 ms] Start: Setup shutdown monitor
[3300 ms] Forking shutdown monitor: /home/rwxr-xr-x/.vscode/extensions/ms-vscode-remote.remote-containers-0.327.0/dist/shutdown/shutdownMonitorProcess /run/user/1000/vscode-remote-containers-772a03e1-6375-4e50-8846-bfc4d93218ab.sock dockerCompose Debug /home/rwxr-xr-x/.config/Code/logs/20231208T032057/window8/exthost/ms-vscode-remote.remote-containers 1702051564484
[3304 ms] Start: Run in container: test -d /home/robin/.vscode-server
[3304 ms] 
[3304 ms] 
[3304 ms] Exit code 1
[3304 ms] Start: Run in container: test -d /home/robin/.vscode-remote
[3304 ms] 
[3304 ms] 
[3305 ms] Exit code 1
[3305 ms] Start: Run in container: test ! -f '/home/robin/.vscode-server/data/Machine/.writeMachineSettingsMarker' && set -o noclobber && mkdir -p '/home/robin/.vscode-server/data/Machine' && { > '/home/robin/.vscode-server/data/Machine/.writeMachineSettingsMarker' ; } 2> /dev/null
[3305 ms] 
[3305 ms] mkdir: cannot create directory '/home/robin/.vscode-server': Permission denied
[3305 ms] Exit code 1
[3305 ms] Start: Run in container: cat /home/robin/.vscode-server/data/Machine/settings.json
[3306 ms] 
[3306 ms] cat: /home/robin/.vscode-server/data/Machine/settings.json: No such file or directory
[3306 ms] Exit code 1
[3306 ms] Start: Run in container: test -d /home/robin/.vscode-server/bin/1a5daa3a0231a0fbba4f14db7ec463cf99d7768e
[3306 ms] 
[3306 ms] 
[3306 ms] Exit code 1
[3306 ms] Start: Run in container: test -d /vscode/vscode-server/bin/linux-x64/1a5daa3a0231a0fbba4f14db7ec463cf99d7768e
[3307 ms] 
[3307 ms] 
[3307 ms] Start: Run in container: mkdir -p '/home/robin/.vscode-server/bin' && ln -snf '/vscode/vscode-server/bin/linux-x64/1a5daa3a0231a0fbba4f14db7ec463cf99d7768e' '/home/robin/.vscode-server/bin/1a5daa3a0231a0fbba4f14db7ec463cf99d7768e'
[3307 ms] 
[3307 ms] mkdir: cannot create directory '/home/robin/.vscode-server': Permission denied
[3308 ms] Exit code 1
[3309 ms] Command in container failed: mkdir -p '/home/robin/.vscode-server/bin' && ln -snf '/vscode/vscode-server/bin/linux-x64/1a5daa3a0231a0fbba4f14db7ec463cf99d7768e' '/home/robin/.vscode-server/bin/1a5daa3a0231a0fbba4f14db7ec463cf99d7768e'
[3310 ms] mkdir: cannot create directory '/home/robin/.vscode-server': Permission denied
[3310 ms] Exit code 1
```

setting the owner of the /home/robin folder to robin fixes the issue.