### PR TITLE
[codex] Fix mici alert text layout

### DIFF
--- a/core/openpilot_integration.py
+++ b/core/openpilot_integration.py
@@ -25,6 +25,7 @@ class OpenpilotPatchReport:
     ui_null_egl: bool = False
     augmented_road_fill: bool = False
     model_renderer_lead_position: bool = False
+    mici_alert_text_layout: bool = False
 
     @property
     def changed(self) -> bool:
@@ -35,6 +36,7 @@ class OpenpilotPatchReport:
                 self.ui_null_egl,
                 self.augmented_road_fill,
                 self.model_renderer_lead_position,
+                self.mici_alert_text_layout,
             )
         )
 
@@ -442,6 +444,21 @@ def _patch_model_renderer_lead_position(path: Path) -> bool:
     return False
 
 
+def _patch_mici_alert_text_layout(path: Path) -> bool:
+    source = path.read_text()
+    updated = source
+
+    old_subtitle_block = """    if can_draw_second_line and alert_text2:\n      last_line_h = self._alert_text1_label.rect.y + self._alert_text1_label.get_content_height(int(alert_layout.text_rect.width))\n      last_line_h -= 4\n      if len(alert_text2) > 18:\n        small_font_size = 36\n      elif len(alert_text2) > 24:\n        small_font_size = 32\n      else:\n        small_font_size = 40\n      text_rect2 = rl.Rectangle(\n        alert_layout.text_rect.x,\n        last_line_h,\n        alert_layout.text_rect.width,\n        alert_layout.text_rect.height - last_line_h\n      )\n      color = rl.Color(255, 255, 255, int(255 * 0.65 * self._alpha_filter.x))\n\n      self._alert_text2_label.set_text(alert_text2)\n      self._alert_text2_label.set_text_color(color)\n      self._alert_text2_label.set_font_size(small_font_size)\n      self._alert_text2_label.set_alignment(rl.GuiTextAlignment.TEXT_ALIGN_LEFT if icon_side != 'left' else rl.GuiTextAlignment.TEXT_ALIGN_RIGHT)\n      self._alert_text2_label.render(text_rect2)\n"""
+    new_subtitle_block = """    if can_draw_second_line and alert_text2:\n      last_line_h = self._alert_text1_label.rect.y + self._alert_text1_label.get_content_height(int(alert_layout.text_rect.width))\n      second_line_top = last_line_h + max(8, int(font_size * 0.14))\n      available_height = max(0, (alert_layout.text_rect.y + alert_layout.text_rect.height) - second_line_top)\n      if len(alert_text2) > 24:\n        small_font_size = 32\n      elif len(alert_text2) > 18:\n        small_font_size = 36\n      else:\n        small_font_size = 40\n      if available_height > 0:\n        text_rect2 = rl.Rectangle(\n          alert_layout.text_rect.x,\n          second_line_top,\n          alert_layout.text_rect.width,\n          available_height,\n        )\n        color = rl.Color(255, 255, 255, int(255 * 0.65 * self._alpha_filter.x))\n\n        self._alert_text2_label.set_text(alert_text2)\n        self._alert_text2_label.set_text_color(color)\n        self._alert_text2_label.set_font_size(small_font_size)\n        self._alert_text2_label.set_alignment(rl.GuiTextAlignment.TEXT_ALIGN_LEFT if icon_side != 'left' else rl.GuiTextAlignment.TEXT_ALIGN_RIGHT)\n        self._alert_text2_label.render(text_rect2)\n"""
+    if old_subtitle_block in updated:
+        updated = updated.replace(old_subtitle_block, new_subtitle_block, 1)
+
+    if updated != source:
+        path.write_text(updated)
+        return True
+    return False
+
+
 def _first_existing(*paths: Path) -> Path | None:
     for path in paths:
         if path.exists():
@@ -500,15 +517,28 @@ def patch_openpilot_model_renderer_lead_position(openpilot_dir: Path) -> bool:
     return patched
 
 
+def patch_openpilot_mici_alert_text_layout(openpilot_dir: Path) -> bool:
+    candidates = (
+        openpilot_dir / "selfdrive/ui/mici/onroad/alert_renderer.py",
+        openpilot_dir / "openpilot/selfdrive/ui/mici/onroad/alert_renderer.py",
+    )
+    for path in candidates:
+        if path.exists():
+            return _patch_mici_alert_text_layout(path)
+    return False
+
+
 def apply_openpilot_runtime_patches(openpilot_dir: Path) -> OpenpilotPatchReport:
     framereader_compat = patch_openpilot_framereader_compat(openpilot_dir)
     ui_recording, ui_null_egl = patch_openpilot_ui_record_skip(openpilot_dir)
     augmented_road_fill = patch_openpilot_augmented_road_view_fill(openpilot_dir)
     model_renderer_lead_position = patch_openpilot_model_renderer_lead_position(openpilot_dir)
+    mici_alert_text_layout = patch_openpilot_mici_alert_text_layout(openpilot_dir)
     return OpenpilotPatchReport(
         framereader_compat=framereader_compat,
         ui_recording=ui_recording,
         ui_null_egl=ui_null_egl,
         augmented_road_fill=augmented_road_fill,
         model_renderer_lead_position=model_renderer_lead_position,
+        mici_alert_text_layout=mici_alert_text_layout,
     )

--- a/tests/test_big_ui_engine.py
+++ b/tests/test_big_ui_engine.py
@@ -1337,11 +1337,49 @@ def test_patch_model_renderer_lead_position_uses_absolute_rect_bounds(tmp_path) 
     assert "y = np.clip(point[1], rect.y, rect.y + rect.height - sz * 0.6)" in updated
 
 
+def test_patch_mici_alert_text_layout_preserves_gap_and_remaining_height(tmp_path) -> None:
+    alert_renderer = tmp_path / "alert_renderer.py"
+    alert_renderer.write_text(
+        "    if can_draw_second_line and alert_text2:\n"
+        "      last_line_h = self._alert_text1_label.rect.y + self._alert_text1_label.get_content_height(int(alert_layout.text_rect.width))\n"
+        "      last_line_h -= 4\n"
+        "      if len(alert_text2) > 18:\n"
+        "        small_font_size = 36\n"
+        "      elif len(alert_text2) > 24:\n"
+        "        small_font_size = 32\n"
+        "      else:\n"
+        "        small_font_size = 40\n"
+        "      text_rect2 = rl.Rectangle(\n"
+        "        alert_layout.text_rect.x,\n"
+        "        last_line_h,\n"
+        "        alert_layout.text_rect.width,\n"
+        "        alert_layout.text_rect.height - last_line_h\n"
+        "      )\n"
+        "      color = rl.Color(255, 255, 255, int(255 * 0.65 * self._alpha_filter.x))\n\n"
+        "      self._alert_text2_label.set_text(alert_text2)\n"
+        "      self._alert_text2_label.set_text_color(color)\n"
+        "      self._alert_text2_label.set_font_size(small_font_size)\n"
+        "      self._alert_text2_label.set_alignment(rl.GuiTextAlignment.TEXT_ALIGN_LEFT if icon_side != 'left' else rl.GuiTextAlignment.TEXT_ALIGN_RIGHT)\n"
+        "      self._alert_text2_label.render(text_rect2)\n"
+    )
+
+    changed = openpilot_integration._patch_mici_alert_text_layout(alert_renderer)
+    updated = alert_renderer.read_text()
+
+    assert changed is True
+    assert "second_line_top = last_line_h + max(8, int(font_size * 0.14))" in updated
+    assert "available_height = max(0, (alert_layout.text_rect.y + alert_layout.text_rect.height) - second_line_top)" in updated
+    assert "if len(alert_text2) > 24:" in updated
+    assert "elif len(alert_text2) > 18:" in updated
+    assert "if available_height > 0:" in updated
+
+
 def test_apply_openpilot_runtime_patches_reports_changed_files(tmp_path) -> None:
     openpilot_dir = tmp_path / "openpilot"
     (openpilot_dir / "tools/lib").mkdir(parents=True)
     (openpilot_dir / "system/ui/lib").mkdir(parents=True)
     (openpilot_dir / "selfdrive/ui/onroad").mkdir(parents=True)
+    (openpilot_dir / "selfdrive/ui/mici/onroad").mkdir(parents=True)
 
     (openpilot_dir / "tools/lib/framereader.py").write_text(
         "def decompress_video_data(fn, fmt, threads=0, hwaccel=None):\n"
@@ -1401,6 +1439,29 @@ def test_apply_openpilot_runtime_patches_reports_changed_files(tmp_path) -> None
         "    x = np.clip(point[0], 0.0, rect.width - sz / 2)\n"
         "    y = min(point[1], rect.height - sz * 0.6)\n"
     )
+    (openpilot_dir / "selfdrive/ui/mici/onroad/alert_renderer.py").write_text(
+        "    if can_draw_second_line and alert_text2:\n"
+        "      last_line_h = self._alert_text1_label.rect.y + self._alert_text1_label.get_content_height(int(alert_layout.text_rect.width))\n"
+        "      last_line_h -= 4\n"
+        "      if len(alert_text2) > 18:\n"
+        "        small_font_size = 36\n"
+        "      elif len(alert_text2) > 24:\n"
+        "        small_font_size = 32\n"
+        "      else:\n"
+        "        small_font_size = 40\n"
+        "      text_rect2 = rl.Rectangle(\n"
+        "        alert_layout.text_rect.x,\n"
+        "        last_line_h,\n"
+        "        alert_layout.text_rect.width,\n"
+        "        alert_layout.text_rect.height - last_line_h\n"
+        "      )\n"
+        "      color = rl.Color(255, 255, 255, int(255 * 0.65 * self._alpha_filter.x))\n\n"
+        "      self._alert_text2_label.set_text(alert_text2)\n"
+        "      self._alert_text2_label.set_text_color(color)\n"
+        "      self._alert_text2_label.set_font_size(small_font_size)\n"
+        "      self._alert_text2_label.set_alignment(rl.GuiTextAlignment.TEXT_ALIGN_LEFT if icon_side != 'left' else rl.GuiTextAlignment.TEXT_ALIGN_RIGHT)\n"
+        "      self._alert_text2_label.render(text_rect2)\n"
+    )
 
     report = openpilot_integration.apply_openpilot_runtime_patches(openpilot_dir)
     updated_application = (openpilot_dir / "system/ui/lib/application.py").read_text()
@@ -1411,6 +1472,7 @@ def test_apply_openpilot_runtime_patches_reports_changed_files(tmp_path) -> None
     assert report.ui_null_egl is True
     assert report.augmented_road_fill is True
     assert report.model_renderer_lead_position is True
+    assert report.mici_alert_text_layout is True
     assert 'RECORD_GOP_FRAMES = os.getenv("RECORD_GOP_FRAMES", "")' in updated_application
     assert "'-g', RECORD_GOP_FRAMES" in updated_application
     assert "'-colorspace', 'bt709'" in updated_application


### PR DESCRIPTION
## What changed
- add a runtime patch for the mici on-road alert renderer so second-line alert text is placed below the primary line with an explicit gap
- compute subtitle height from the remaining alert area instead of subtracting an absolute y-position from a relative height
- fix the subtitle font-size threshold ordering so longer secondary text can shrink as intended
- add regression coverage for the new alert-layout patch and include it in the runtime patch report test

## Why
Mici two-line alerts with short primary text could render the subtitle directly on top of the main alert text. In practice this showed up as `Risk of Collision` mashing into `BRAKE!`, but the same renderer bug could affect other short two-line alerts like lane-change confirmations and distraction warnings.

## Impact
This keeps high-priority mici alerts readable in generated clips and makes the runtime patch reporting explicit when the alert-layout rewrite is applied.

## Validation
- `uv run pytest tests/test_big_ui_engine.py -k "mici_alert_text_layout or apply_openpilot_runtime_patches_reports_changed_files or model_renderer_lead_position"`
- `uv run python -m compileall core/openpilot_integration.py tests/test_big_ui_engine.py`
