### PR TITLE
Improve Connect clip URL error

### DIFF
--- a/core/route_inputs.py
+++ b/core/route_inputs.py
@@ -9,7 +9,8 @@ LITERAL_URL_PREFIX = "literal:"
 CONNECT_CLIP_URL_HELP = (
     "Expected a full comma Connect clip URL with start and end seconds, like "
     "https://connect.comma.ai/<dongle>/<route>/<start>/<end>. "
-    "In Connect, follow the README Quick Usage steps: select a route, drag-select the clip window, "
+    "In Connect, follow the README Quick Usage steps at "
+    "https://github.com/nelsonjchen/op-replay-clipper#quick-usage: select a route, drag-select the clip window, "
     "then copy the browser URL. The last two numbers should be the clip start second and end second."
 )
 

--- a/core/route_inputs.py
+++ b/core/route_inputs.py
@@ -6,6 +6,12 @@ from urllib.parse import urlparse
 
 
 LITERAL_URL_PREFIX = "literal:"
+CONNECT_CLIP_URL_HELP = (
+    "Expected a full comma Connect clip URL with start and end seconds, like "
+    "https://connect.comma.ai/<dongle>/<route>/<start>/<end>. "
+    "In Connect, follow the README Quick Usage steps: select a route, drag-select the clip window, "
+    "then copy the browser URL. The last two numbers should be the clip start second and end second."
+)
 
 
 def _coerce_route_text(route_or_url: Any) -> str:
@@ -40,7 +46,7 @@ def validate_connect_url(route_or_url: str | os.PathLike[str], *, error_message:
     route_or_url = _normalize_route_text(route_or_url)
     parsed = urlparse(route_or_url)
     if parsed.scheme != "https" or parsed.hostname != "connect.comma.ai":
-        raise ValueError(error_message or "Expected a full https://connect.comma.ai/... clip URL.")
+        raise ValueError(error_message or CONNECT_CLIP_URL_HELP)
     return route_or_url
 
 # These have a dash in the 2nd part and 4 parts
@@ -68,9 +74,16 @@ def parseRouteRelativeUrl(
     segment_name = path_parts[2]
     internal_route_name = f"{dongle_id}|{segment_name}"
     # The third part should be the start time relative to the start time of the route
-    start_time = int(path_parts[3])
+    try:
+        start_time = int(path_parts[3])
+        end_time = int(path_parts[4])
+    except ValueError as exc:
+        raise ValueError(CONNECT_CLIP_URL_HELP) from exc
     # The fourth part should be end time relative to the start time of the route
-    end_time = int(path_parts[4])
+    if end_time <= start_time:
+        raise ValueError(
+            f"Connect clip URL end second must be greater than the start second. Got start={start_time}, end={end_time}."
+        )
 
 
     start_seconds = start_time
@@ -276,10 +289,8 @@ def parseRouteOrUrl(
     if len(url_parts) == 5 and "-" in url_parts[2]:
         return parseRouteRelativeUrl(route_or_url, jwt_token)
 
-    print("Number of url parts: ", len(url_parts))
-
     # If the URL is not an absolute time URL, throw an exception
-    raise ValueError("Invalid URL")
+    raise ValueError(CONNECT_CLIP_URL_HELP)
 
 # Make an argparse test for this
 if __name__ == "__main__":

--- a/tests/test_clip_orchestrator.py
+++ b/tests/test_clip_orchestrator.py
@@ -72,6 +72,24 @@ def test_build_plan_parses_route_for_ui_requests() -> None:
     assert plan.target_mb == 8
 
 
+def test_build_plan_explains_connect_url_missing_clip_window() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        clip_orchestrator.build_clip_plan(
+            clip_orchestrator.ClipRequest(
+                render_type="ui",
+                route_or_url="https://connect.comma.ai/a2a0ccea32023010/000001bb--4c0c0efba9",
+                start_seconds=0,
+                length_seconds=0,
+                target_mb=9,
+            )
+        )
+
+    message = str(excinfo.value)
+    assert "start and end seconds" in message
+    assert "README Quick Usage" in message
+    assert "last two numbers" in message
+
+
 def test_build_plan_treats_ui_alt_as_ui_render() -> None:
     plan = clip_orchestrator.build_clip_plan(
         clip_orchestrator.ClipRequest(

--- a/tests/test_clip_orchestrator.py
+++ b/tests/test_clip_orchestrator.py
@@ -86,7 +86,7 @@ def test_build_plan_explains_connect_url_missing_clip_window() -> None:
 
     message = str(excinfo.value)
     assert "start and end seconds" in message
-    assert "README Quick Usage" in message
+    assert "https://github.com/nelsonjchen/op-replay-clipper#quick-usage" in message
     assert "last two numbers" in message
 
 

--- a/tests/test_replicate_run.py
+++ b/tests/test_replicate_run.py
@@ -390,6 +390,7 @@ def test_validate_connect_url_rejects_non_connect_hosts() -> None:
         message = str(exc)
         assert "start and end seconds" in message
         assert "https://connect.comma.ai/<dongle>/<route>/<start>/<end>" in message
+        assert "https://github.com/nelsonjchen/op-replay-clipper#quick-usage" in message
     else:
         raise AssertionError("validate_connect_url should reject non-connect URLs")
 

--- a/tests/test_replicate_run.py
+++ b/tests/test_replicate_run.py
@@ -387,7 +387,9 @@ def test_validate_connect_url_rejects_non_connect_hosts() -> None:
     try:
         replicate_run.validate_connect_url("https://example.com/not-connect")
     except SystemExit as exc:
-        assert str(exc) == "Expected a full https://connect.comma.ai/... clip URL."
+        message = str(exc)
+        assert "start and end seconds" in message
+        assert "https://connect.comma.ai/<dongle>/<route>/<start>/<end>" in message
     else:
         raise AssertionError("validate_connect_url should reject non-connect URLs")
 


### PR DESCRIPTION
## Summary
- replace the generic invalid Connect URL error with guidance to use a full clip URL containing start/end seconds
- validate route-relative Connect clip URLs with non-numeric or reversed start/end values
- add a regression test for route URLs missing the selected clip window

## Tests
- uv run pytest tests/test_clip_orchestrator.py tests/test_cog_predictor.py -q
- uv run pytest tests/test_route_downloader.py tests/test_clip_orchestrator.py -q