### PR TITLE
[codex] Fix model commit overlay lookup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 REPLICATE_API_TOKEN=your_replicate_api_token_here
+COMMA_JWT=your_comma_jwt_here

--- a/comma_watch.py
+++ b/comma_watch.py
@@ -7,7 +7,7 @@ import json
 import os
 import time
 from dataclasses import dataclass
-from datetime import date, datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterable
 from urllib.parse import urljoin
@@ -41,6 +41,7 @@ class Route:
     fullname: str
     route_id: str
     start_time: str | None
+    end_time: str | None
     maxqlog: int
     procqlog: int | None
     url: str
@@ -144,9 +145,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--jwt-token", default=os.environ.get("COMMA_JWT", ""), help="Comma JWT token. Defaults to COMMA_JWT.")
     parser.add_argument("--timezone", default=os.environ.get("TZ", "America/Los_Angeles"))
     parser.add_argument(
-        "--date",
-        default="today",
-        help="Target local date in YYYY-MM-DD format, or 'today'. Defaults to today's date in --timezone.",
+        "--lookback-hours",
+        type=int,
+        default=48,
+        help="Only inspect routes whose local start time is within this many hours. Defaults to 48.",
     )
     parser.add_argument("--poll-seconds", type=int, default=30, help="Polling interval while waiting for bookmarks or uploads.")
     parser.add_argument(
@@ -192,12 +194,6 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def local_date_from_arg(raw: str, tz: ZoneInfo) -> date:
-    if raw == "today":
-        return datetime.now(tz).date()
-    return date.fromisoformat(raw)
-
-
 def parse_route_start_local(start_time: str | None, tz: ZoneInfo) -> datetime | None:
     if not start_time:
         return None
@@ -239,7 +235,7 @@ def select_devices(devices: Iterable[dict[str, Any]], device_alias: str | None, 
     return selected
 
 
-def list_routes_for_local_date(api: CommaApi, dongle_id: str, target_date: date, tz: ZoneInfo) -> list[Route]:
+def list_routes_in_lookback_window(api: CommaApi, dongle_id: str, *, window_start: datetime, tz: ZoneInfo) -> list[Route]:
     routes: list[Route] = []
     created_before: int | None = None
 
@@ -249,16 +245,13 @@ def list_routes_for_local_date(api: CommaApi, dongle_id: str, target_date: date,
             break
         for item in batch:
             start_local = parse_route_start_local(item.get("start_time"), tz)
-            if start_local is None:
-                route_date = datetime.now(tz).date()
-            else:
-                route_date = start_local.date()
-            if route_date == target_date:
+            if start_local is not None and start_local >= window_start:
                 routes.append(
                     Route(
                         fullname=item["fullname"],
                         route_id=route_id_from_fullname(item["fullname"]),
                         start_time=item.get("start_time"),
+                        end_time=item.get("end_time"),
                         maxqlog=item.get("maxqlog", 0),
                         procqlog=item.get("procqlog"),
                         url=item["url"],
@@ -266,7 +259,7 @@ def list_routes_for_local_date(api: CommaApi, dongle_id: str, target_date: date,
                 )
         created_before = batch[-1]["create_time"]
         oldest_local = parse_route_start_local(batch[-1].get("start_time"), tz)
-        if oldest_local is not None and oldest_local.date() < target_date:
+        if oldest_local is not None and oldest_local < window_start:
             break
 
     routes.sort(key=lambda route: parse_route_start_local(route.start_time, tz) or datetime.max.replace(tzinfo=tz))
@@ -298,6 +291,28 @@ def expand_segments(bookmarked: Iterable[int], *, previous_segments: int, next_s
         end = min(max_segment, segment + next_segments)
         expanded.update(range(start, end + 1))
     return sorted(expanded)
+
+
+def prioritize_segments(bookmarked: Iterable[int], *, previous_segments: int, next_segments: int, max_segment: int) -> list[int]:
+    ordered: list[int] = []
+    seen: set[int] = set()
+
+    for segment in bookmarked:
+        candidates = [segment]
+        if previous_segments >= 1:
+            candidates.append(segment - 1)
+        if next_segments >= 1:
+            candidates.append(segment + 1)
+        for offset in range(2, previous_segments + 1):
+            candidates.append(segment - offset)
+
+        for candidate in candidates:
+            if candidate < 0 or candidate > max_segment or candidate in seen:
+                continue
+            seen.add(candidate)
+            ordered.append(candidate)
+
+    return ordered
 
 
 def normalize_uploaded_paths(filelist: dict[str, list[str]]) -> set[str]:
@@ -354,6 +369,9 @@ def generate_candidate_paths(route: Route, segments: Iterable[int], file_types: 
     candidates: list[str] = []
     for segment in segments:
         for file_type in file_types:
+            if file_type == "logs":
+                candidates.append(f"{route.route_id}--{segment}/rlog.zst")
+                continue
             for filename in FILE_TYPE_NAMES[file_type]:
                 candidates.append(f"{route.route_id}--{segment}/{filename}")
     return candidates
@@ -384,7 +402,7 @@ def scan_once(
     api: CommaApi,
     *,
     device_alias: str,
-    target_date: date,
+    lookback_hours: int,
     tz: ZoneInfo,
     previous_segments: int,
     next_segments: int,
@@ -396,15 +414,20 @@ def scan_once(
     all_bookmarked_files_satisfied = True
     queue_cleared = False
     devices = select_devices(api.get_devices(), device_alias or None)
-    print(f"[{datetime.now(tz).isoformat()}] Watching {len(devices)} device(s) on {target_date.isoformat()}")
+    now_local = datetime.now(tz)
+    window_start = now_local - timedelta(hours=lookback_hours)
+    print(
+        f"[{now_local.isoformat()}] Watching {len(devices)} device(s) in the last {lookback_hours} hour(s) "
+        f"since {window_start.isoformat()}"
+    )
     if not devices:
         return ScanOutcome(bookmarks_found=False, uploads_queued=False, all_bookmarked_files_satisfied=False, queue_cleared=False)
 
     any_routes_found = False
     for device in devices:
         print(f"Device {device.alias or device.dongle_id} ({device.dongle_id})")
-        routes = list_routes_for_local_date(api, device.dongle_id, target_date, tz)
-        print(f"Found {len(routes)} route(s) for target date")
+        routes = list_routes_in_lookback_window(api, device.dongle_id, window_start=window_start, tz=tz)
+        print(f"Found {len(routes)} route(s) in lookback window")
         if not routes:
             continue
         any_routes_found = True
@@ -421,6 +444,7 @@ def scan_once(
                 fullname=route.fullname,
                 route_id=route.route_id,
                 start_time=route_detail.get("start_time"),
+                end_time=route_detail.get("end_time", route.end_time),
                 maxqlog=route_detail.get("maxqlog", route.maxqlog),
                 procqlog=route_detail.get("procqlog", route.procqlog),
                 url=route_detail.get("url", route.url),
@@ -448,10 +472,17 @@ def scan_once(
                 next_segments=next_segments,
                 max_segment=hydrated_route.maxqlog,
             )
+            prioritized_segments = prioritize_segments(
+                bookmark_segments,
+                previous_segments=previous_segments,
+                next_segments=next_segments,
+                max_segment=hydrated_route.maxqlog,
+            )
             print(f"Expanded segment window: {target_segments}")
+            print(f"Upload priority order: {prioritized_segments}")
 
             uploaded_paths = normalize_uploaded_paths(route_files)
-            desired_paths = generate_candidate_paths(hydrated_route, target_segments, file_types)
+            desired_paths = generate_candidate_paths(hydrated_route, prioritized_segments, file_types)
             target_paths.update(desired_paths)
             missing_paths = [path for path in desired_paths if path not in uploaded_paths and path not in queued_paths]
             print(
@@ -505,7 +536,6 @@ def main() -> int:
         raise SystemExit("Missing JWT token. Set COMMA_JWT or pass --jwt-token.")
 
     tz = ZoneInfo(args.timezone)
-    target_date = local_date_from_arg(args.date, tz)
     api = CommaApi(args.jwt_token)
 
     start_time = time.monotonic()
@@ -515,7 +545,7 @@ def main() -> int:
             outcome = scan_once(
                 api,
                 device_alias=args.device_alias,
-                target_date=target_date,
+                lookback_hours=args.lookback_hours,
                 tz=tz,
                 previous_segments=args.previous_segments,
                 next_segments=args.next_segments,

--- a/comma_watch.py
+++ b/comma_watch.py
@@ -19,7 +19,7 @@ from zoneinfo import ZoneInfo
 
 API_URL = "https://api.comma.ai"
 ATHENA_URL = "https://athena.comma.ai"
-DEFAULT_FILE_TYPES = ("cameras", "dcameras", "ecameras", "logs")
+DEFAULT_FILE_TYPES = ("cameras", "logs", "ecameras", "dcameras")
 ONLINE_DEVICE_WINDOW_SECONDS = 120
 FILE_TYPE_NAMES = {
     "cameras": ("fcamera.hevc",),
@@ -28,6 +28,8 @@ FILE_TYPE_NAMES = {
     "logs": ("rlog.bz2", "rlog.zst"),
 }
 BOOKMARK_EVENT_TYPES = {"user_flag", "user_bookmark", "bookmark"}
+USER_PROMPT_ALERT_STATUSES = {1, "1", "userPrompt", "user_prompt"}
+OVERRIDE_STATES = {"overriding", "preEnabled"}
 
 
 @dataclass(frozen=True)
@@ -56,10 +58,17 @@ class UploadFile:
 
 @dataclass(frozen=True)
 class ScanOutcome:
-    bookmarks_found: bool
+    targets_found: bool
     uploads_queued: bool
-    all_bookmarked_files_satisfied: bool
+    all_target_files_satisfied: bool
     queue_cleared: bool
+
+
+@dataclass(frozen=True)
+class PrioritySegments:
+    bookmark_segments: list[int]
+    alert_segments: list[int]
+    override_segments: list[int]
 
 
 class CommaApi:
@@ -135,7 +144,7 @@ class CommaApi:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Watch Comma routes for bookmark flags and queue high-quality uploads around them."
+        description="Watch Comma routes for bookmarks, alerts, and overrides and queue high-quality uploads."
     )
     parser.add_argument(
         "--device-alias",
@@ -189,7 +198,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--exclusive-bookmark-priority",
         action="store_true",
-        help="Keep the upload queue clear until bookmarks exist, then keep only bookmark-related uploads queued.",
+        help="Keep the upload queue clear until bookmarks/alerts/overrides exist, then keep only those uploads queued.",
     )
     return parser.parse_args()
 
@@ -272,16 +281,60 @@ def parsed_segment_upper_bound(route: Route) -> int:
     return max(0, min(route.procqlog, route.maxqlog))
 
 
-def bookmarked_segments(api: CommaApi, route: Route) -> list[int]:
-    segments: set[int] = set()
+def segment_from_event(event: dict[str, Any], *, default_segment: int, max_segment: int) -> int:
+    route_offset_millis = event.get("route_offset_millis")
+    if route_offset_millis is None:
+        return default_segment
+    try:
+        segment = int(route_offset_millis) // 60000
+    except (TypeError, ValueError):
+        return default_segment
+    return max(0, min(max_segment, segment))
+
+
+def categorize_segment_events(
+    events: Iterable[dict[str, Any]], *, segment: int, max_segment: int
+) -> tuple[set[int], set[int], set[int]]:
+    bookmarks: set[int] = set()
+    alerts: set[int] = set()
+    overrides: set[int] = set()
+
+    for event in events:
+        target_segment = segment_from_event(event, default_segment=segment, max_segment=max_segment)
+        event_type = event.get("type")
+        data = event.get("data") or {}
+
+        if event_type in BOOKMARK_EVENT_TYPES:
+            bookmarks.add(target_segment)
+        if data.get("alertStatus") in USER_PROMPT_ALERT_STATUSES:
+            alerts.add(target_segment)
+        if event_type == "overriding" or data.get("state") in OVERRIDE_STATES:
+            overrides.add(target_segment)
+
+    return bookmarks, alerts, overrides
+
+
+def collect_priority_segments(api: CommaApi, route: Route) -> PrioritySegments:
+    bookmark_segments: set[int] = set()
+    alert_segments: set[int] = set()
+    override_segments: set[int] = set()
+
     for seg in range(parsed_segment_upper_bound(route) + 1):
-        events = api.get_events(route.url, seg)
-        for event in events:
-            if event.get("type") not in BOOKMARK_EVENT_TYPES:
-                continue
-            route_offset_millis = int(event["route_offset_millis"])
-            segments.add(route_offset_millis // 60000)
-    return sorted(segments)
+        try:
+            events = api.get_events(route.url, seg)
+        except requests.RequestException as exc:
+            print(f"Skipping events for {route.route_id} seg={seg}: {exc}")
+            continue
+        bookmarks, alerts, overrides = categorize_segment_events(events, segment=seg, max_segment=route.maxqlog)
+        bookmark_segments.update(bookmarks)
+        alert_segments.update(alerts)
+        override_segments.update(overrides)
+
+    return PrioritySegments(
+        bookmark_segments=sorted(bookmark_segments),
+        alert_segments=sorted(alert_segments),
+        override_segments=sorted(override_segments),
+    )
 
 
 def expand_segments(bookmarked: Iterable[int], *, previous_segments: int, next_segments: int, max_segment: int) -> list[int]:
@@ -313,6 +366,47 @@ def prioritize_segments(bookmarked: Iterable[int], *, previous_segments: int, ne
             ordered.append(candidate)
 
     return ordered
+
+
+def combine_priority_segments(
+    *,
+    bookmark_segments: Iterable[int],
+    alert_segments: Iterable[int],
+    override_segments: Iterable[int],
+    previous_segments: int,
+    next_segments: int,
+    max_segment: int,
+) -> tuple[list[int], list[list[int]]]:
+    bookmark_window = expand_segments(
+        bookmark_segments,
+        previous_segments=previous_segments,
+        next_segments=next_segments,
+        max_segment=max_segment,
+    )
+    seen: set[int] = set()
+    grouped_segments: list[list[int]] = []
+
+    bookmark_order = prioritize_segments(
+        bookmark_segments,
+        previous_segments=previous_segments,
+        next_segments=next_segments,
+        max_segment=max_segment,
+    )
+    grouped_segments.append([])
+    for segment in bookmark_order:
+        if segment not in seen:
+            seen.add(segment)
+            grouped_segments[-1].append(segment)
+
+    for bucket in (alert_segments, override_segments):
+        grouped_segments.append([])
+        for segment in bucket:
+            if segment < 0 or segment > max_segment or segment in seen:
+                continue
+            seen.add(segment)
+            grouped_segments[-1].append(segment)
+
+    return bookmark_window, grouped_segments
 
 
 def normalize_uploaded_paths(filelist: dict[str, list[str]]) -> set[str]:
@@ -377,6 +471,23 @@ def generate_candidate_paths(route: Route, segments: Iterable[int], file_types: 
     return candidates
 
 
+def generate_candidate_paths_by_priority(
+    route: Route, segment_groups: Iterable[Iterable[int]], file_types: Iterable[str]
+) -> list[str]:
+    candidates: list[str] = []
+    for segments in segment_groups:
+        segment_list = list(segments)
+        for file_type in file_types:
+            if file_type == "logs":
+                for segment in segment_list:
+                    candidates.append(f"{route.route_id}--{segment}/rlog.zst")
+                continue
+            for segment in segment_list:
+                for filename in FILE_TYPE_NAMES[file_type]:
+                    candidates.append(f"{route.route_id}--{segment}/{filename}")
+    return candidates
+
+
 def request_uploads(api: CommaApi, dongle_id: str, paths: list[str]) -> dict[str, Any]:
     upload_metadata = api.request_upload_urls(dongle_id, paths)
     files = [
@@ -409,9 +520,9 @@ def scan_once(
     file_types: list[str],
     exclusive_bookmark_priority: bool,
 ) -> ScanOutcome:
-    bookmarks_found = False
+    targets_found = False
     uploads_queued = False
-    all_bookmarked_files_satisfied = True
+    all_target_files_satisfied = True
     queue_cleared = False
     devices = select_devices(api.get_devices(), device_alias or None)
     now_local = datetime.now(tz)
@@ -421,7 +532,7 @@ def scan_once(
         f"since {window_start.isoformat()}"
     )
     if not devices:
-        return ScanOutcome(bookmarks_found=False, uploads_queued=False, all_bookmarked_files_satisfied=False, queue_cleared=False)
+        return ScanOutcome(targets_found=False, uploads_queued=False, all_target_files_satisfied=False, queue_cleared=False)
 
     any_routes_found = False
     for device in devices:
@@ -437,7 +548,7 @@ def scan_once(
         queued_paths = normalize_queue_paths(online_queue, offline_queue)
         target_paths: set[str] = set()
 
-        device_bookmarks_found = False
+        device_targets_found = False
         for route in routes:
             route_detail = api.get_route(route.fullname)
             hydrated_route = Route(
@@ -459,37 +570,40 @@ def scan_once(
             )
             if parsed_upper_bound < hydrated_route.maxqlog:
                 print(f"Waiting for parsed qlogs: scanning segments 0..{parsed_upper_bound} so far")
-            bookmark_segments = bookmarked_segments(api, hydrated_route)
-            print(f"Bookmarked segments: {bookmark_segments}")
-            if not bookmark_segments:
+            priority_segments = collect_priority_segments(api, hydrated_route)
+            print(f"Bookmarked segments: {priority_segments.bookmark_segments}")
+            print(f"Alert segments: {priority_segments.alert_segments}")
+            print(f"Override segments: {priority_segments.override_segments}")
+            if not (
+                priority_segments.bookmark_segments
+                or priority_segments.alert_segments
+                or priority_segments.override_segments
+            ):
                 continue
 
-            bookmarks_found = True
-            device_bookmarks_found = True
-            target_segments = expand_segments(
-                bookmark_segments,
+            targets_found = True
+            device_targets_found = True
+            bookmark_window, prioritized_segment_groups = combine_priority_segments(
+                bookmark_segments=priority_segments.bookmark_segments,
+                alert_segments=priority_segments.alert_segments,
+                override_segments=priority_segments.override_segments,
                 previous_segments=previous_segments,
                 next_segments=next_segments,
                 max_segment=hydrated_route.maxqlog,
             )
-            prioritized_segments = prioritize_segments(
-                bookmark_segments,
-                previous_segments=previous_segments,
-                next_segments=next_segments,
-                max_segment=hydrated_route.maxqlog,
-            )
-            print(f"Expanded segment window: {target_segments}")
+            prioritized_segments = [segment for group in prioritized_segment_groups for segment in group]
+            print(f"Expanded bookmark window: {bookmark_window}")
             print(f"Upload priority order: {prioritized_segments}")
 
             uploaded_paths = normalize_uploaded_paths(route_files)
-            desired_paths = generate_candidate_paths(hydrated_route, prioritized_segments, file_types)
+            desired_paths = generate_candidate_paths_by_priority(hydrated_route, prioritized_segment_groups, file_types)
             target_paths.update(desired_paths)
             missing_paths = [path for path in desired_paths if path not in uploaded_paths and path not in queued_paths]
             print(
                 f"Desired files={len(desired_paths)} uploaded={len(uploaded_paths)} queued={len(queued_paths)} missing={len(missing_paths)}"
             )
             if not missing_paths:
-                print("Bookmarked route is already uploaded or queued.")
+                print("Priority route files are already uploaded or queued.")
                 continue
 
             response = request_uploads(api, device.dongle_id, missing_paths)
@@ -497,10 +611,10 @@ def scan_once(
             print(json.dumps(response, indent=2))
             queued_paths.update(missing_paths)
             uploads_queued = True
-            all_bookmarked_files_satisfied = False
+            all_target_files_satisfied = False
 
         if exclusive_bookmark_priority:
-            if device_bookmarks_found:
+            if device_targets_found:
                 cancel_ids = [
                     item["id"]
                     for item in online_queue
@@ -508,23 +622,23 @@ def scan_once(
                 ]
                 if cancel_ids:
                     response = api.cancel_uploads(device.dongle_id, cancel_ids)
-                    print(f"Canceled {len(cancel_ids)} non-bookmark queue item(s):")
+                    print(f"Canceled {len(cancel_ids)} non-priority queue item(s):")
                     print(json.dumps(response, indent=2))
                     queue_cleared = True
             else:
                 cancel_ids = [item["id"] for item in online_queue if item.get("id")]
                 if cancel_ids:
                     response = api.cancel_uploads(device.dongle_id, cancel_ids)
-                    print(f"Canceled {len(cancel_ids)} queue item(s) while waiting for bookmarks:")
+                    print(f"Canceled {len(cancel_ids)} queue item(s) while waiting for priority segments:")
                     print(json.dumps(response, indent=2))
                     queue_cleared = True
 
-    if not any_routes_found or not bookmarks_found:
-        all_bookmarked_files_satisfied = False
+    if not any_routes_found or not targets_found:
+        all_target_files_satisfied = False
     return ScanOutcome(
-        bookmarks_found=bookmarks_found,
+        targets_found=targets_found,
         uploads_queued=uploads_queued,
-        all_bookmarked_files_satisfied=all_bookmarked_files_satisfied,
+        all_target_files_satisfied=all_target_files_satisfied,
         queue_cleared=queue_cleared,
     )
 
@@ -539,7 +653,7 @@ def main() -> int:
     api = CommaApi(args.jwt_token)
 
     start_time = time.monotonic()
-    outcome = ScanOutcome(bookmarks_found=False, uploads_queued=False, all_bookmarked_files_satisfied=False, queue_cleared=False)
+    outcome = ScanOutcome(targets_found=False, uploads_queued=False, all_target_files_satisfied=False, queue_cleared=False)
     while True:
         try:
             outcome = scan_once(
@@ -552,18 +666,18 @@ def main() -> int:
                 file_types=args.file_types,
                 exclusive_bookmark_priority=args.exclusive_bookmark_priority,
             )
-            if args.exit_when_satisfied and outcome.bookmarks_found and (
-                outcome.uploads_queued or outcome.all_bookmarked_files_satisfied
+            if args.exit_when_satisfied and outcome.targets_found and (
+                outcome.uploads_queued or outcome.all_target_files_satisfied
             ):
-                print("Bookmarks found and upload work is queued or already complete. Exiting watcher.")
+                print("Priority segments found and upload work is queued or already complete. Exiting watcher.")
                 return 0
         except Exception as exc:
             print(f"Watcher error: {exc}")
 
         if args.once:
-            return 0 if outcome.bookmarks_found and (outcome.uploads_queued or outcome.all_bookmarked_files_satisfied) else 1
+            return 0 if outcome.targets_found and (outcome.uploads_queued or outcome.all_target_files_satisfied) else 1
         if args.timeout_seconds > 0 and time.monotonic() - start_time >= args.timeout_seconds:
-            print("Timed out waiting for bookmarked segments.")
+            print("Timed out waiting for priority segments.")
             return 1
         print(f"Sleeping for {args.poll_seconds} seconds")
         time.sleep(args.poll_seconds)

--- a/comma_watch.py
+++ b/comma_watch.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urljoin
+
+import requests
+from dotenv import load_dotenv
+from zoneinfo import ZoneInfo
+
+
+API_URL = "https://api.comma.ai"
+ATHENA_URL = "https://athena.comma.ai"
+DEFAULT_FILE_TYPES = ("cameras", "dcameras", "ecameras", "logs")
+ONLINE_DEVICE_WINDOW_SECONDS = 120
+FILE_TYPE_NAMES = {
+    "cameras": ("fcamera.hevc",),
+    "dcameras": ("dcamera.hevc",),
+    "ecameras": ("ecamera.hevc",),
+    "logs": ("rlog.bz2", "rlog.zst"),
+}
+BOOKMARK_EVENT_TYPES = {"user_flag", "user_bookmark", "bookmark"}
+
+
+@dataclass(frozen=True)
+class Device:
+    alias: str | None
+    dongle_id: str
+
+
+@dataclass(frozen=True)
+class Route:
+    fullname: str
+    route_id: str
+    start_time: str | None
+    maxqlog: int
+    procqlog: int | None
+    url: str
+
+
+@dataclass(frozen=True)
+class UploadFile:
+    file_path: str
+    url: str
+    headers: dict[str, str]
+
+
+@dataclass(frozen=True)
+class ScanOutcome:
+    bookmarks_found: bool
+    uploads_queued: bool
+    all_bookmarked_files_satisfied: bool
+    queue_cleared: bool
+
+
+class CommaApi:
+    def __init__(self, jwt_token: str, *, session: requests.Session | None = None) -> None:
+        self.session = session or requests.Session()
+        self.session.headers.update({"Authorization": f"JWT {jwt_token}"})
+
+    def get_devices(self) -> list[dict[str, Any]]:
+        return self._get_json("/v1/me/devices")
+
+    def get_routes(self, dongle_id: str, *, limit: int = 100, created_before: int | None = None) -> list[dict[str, Any]]:
+        endpoint = f"/v1/devices/{dongle_id}/routes?limit={limit}"
+        if created_before is not None:
+            endpoint += f"&created_before={created_before}"
+        return self._get_json(endpoint)
+
+    def get_route(self, route_name: str) -> dict[str, Any]:
+        return self._get_json(f"/v1/route/{route_name}/")
+
+    def get_route_files(self, route_name: str) -> dict[str, list[str]]:
+        return self._get_json(f"/v1/route/{route_name}/files")
+
+    def request_upload_urls(self, dongle_id: str, paths: list[str], *, expiry_days: int = 7) -> list[dict[str, Any]]:
+        return self._post_json(
+            f"/v1/{dongle_id}/upload_urls/",
+            {"expiry_days": expiry_days, "paths": paths},
+            api_url=API_URL,
+        )
+
+    def get_athena_offline_queue(self, dongle_id: str) -> list[dict[str, Any]]:
+        return self._get_json(f"/v1/devices/{dongle_id}/athena_offline_queue")
+
+    def athena_call(self, dongle_id: str, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        return self._post_jsonrpc(dongle_id, method, params)
+
+    def cancel_uploads(self, dongle_id: str, upload_ids: list[str]) -> dict[str, Any] | None:
+        if not upload_ids:
+            return None
+        return self.athena_call(dongle_id, "cancelUpload", {"upload_id": upload_ids})
+
+    def get_events(self, route_url: str, segment: int) -> list[dict[str, Any]]:
+        response = requests.get(f"{route_url}/{segment}/events.json", timeout=30)
+        if response.status_code == 404:
+            return []
+        response.raise_for_status()
+        return response.json()
+
+    def _get_json(self, endpoint: str) -> Any:
+        response = self.session.get(urljoin(API_URL, endpoint), timeout=30)
+        response.raise_for_status()
+        return response.json()
+
+    def _post_json(self, endpoint: str, payload: dict[str, Any], *, api_url: str) -> Any:
+        response = self.session.post(
+            urljoin(api_url, endpoint),
+            json=payload,
+            headers={"Content-Type": "application/json"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def _post_jsonrpc(self, dongle_id: str, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        response = self.session.post(
+            f"{ATHENA_URL}/{dongle_id}",
+            json={"id": 0, "jsonrpc": "2.0", "method": method, "params": params},
+            headers={"Content-Type": "application/json"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Watch Comma routes for bookmark flags and queue high-quality uploads around them."
+    )
+    parser.add_argument(
+        "--device-alias",
+        default=os.environ.get("COMMA_DEVICE_ALIAS", ""),
+        help="Optional device alias filter. If omitted, scans every owned online device.",
+    )
+    parser.add_argument("--jwt-token", default=os.environ.get("COMMA_JWT", ""), help="Comma JWT token. Defaults to COMMA_JWT.")
+    parser.add_argument("--timezone", default=os.environ.get("TZ", "America/Los_Angeles"))
+    parser.add_argument(
+        "--date",
+        default="today",
+        help="Target local date in YYYY-MM-DD format, or 'today'. Defaults to today's date in --timezone.",
+    )
+    parser.add_argument("--poll-seconds", type=int, default=30, help="Polling interval while waiting for bookmarks or uploads.")
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=0,
+        help="How long to watch before exiting. Use 0 to run forever.",
+    )
+    parser.add_argument(
+        "--previous-segments",
+        type=int,
+        default=3,
+        help="How many segments before each bookmarked segment to upload.",
+    )
+    parser.add_argument(
+        "--next-segments",
+        type=int,
+        default=1,
+        help="How many segments after each bookmarked segment to upload.",
+    )
+    parser.add_argument(
+        "--file-types",
+        nargs="+",
+        choices=sorted(FILE_TYPE_NAMES),
+        default=list(DEFAULT_FILE_TYPES),
+        help="High-quality file types to queue.",
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Run one scan and exit instead of polling.",
+    )
+    parser.add_argument(
+        "--exit-when-satisfied",
+        action="store_true",
+        help="Exit once bookmarked segments are already uploaded or successfully queued.",
+    )
+    parser.add_argument(
+        "--exclusive-bookmark-priority",
+        action="store_true",
+        help="Keep the upload queue clear until bookmarks exist, then keep only bookmark-related uploads queued.",
+    )
+    return parser.parse_args()
+
+
+def local_date_from_arg(raw: str, tz: ZoneInfo) -> date:
+    if raw == "today":
+        return datetime.now(tz).date()
+    return date.fromisoformat(raw)
+
+
+def parse_route_start_local(start_time: str | None, tz: ZoneInfo) -> datetime | None:
+    if not start_time:
+        return None
+    return datetime.fromisoformat(start_time).replace(tzinfo=timezone.utc).astimezone(tz)
+
+
+def route_id_from_fullname(fullname: str) -> str:
+    return fullname.split("|", 1)[1]
+
+
+def find_device(devices: Iterable[dict[str, Any]], alias: str) -> Device:
+    for device in devices:
+        if device.get("alias") == alias:
+            return Device(alias=device.get("alias"), dongle_id=device["dongle_id"])
+    raise ValueError(f"Could not find a device with alias {alias!r}.")
+
+
+def is_owned_online_device(device: dict[str, Any], *, now: int | None = None) -> bool:
+    if not device.get("is_owner"):
+        return False
+    last_ping = device.get("last_athena_ping") or 0
+    if now is None:
+        now = int(time.time())
+    return last_ping >= now - ONLINE_DEVICE_WINDOW_SECONDS
+
+
+def select_devices(devices: Iterable[dict[str, Any]], device_alias: str | None, *, now: int | None = None) -> list[Device]:
+    if device_alias:
+        return [find_device(devices, device_alias)]
+
+    if now is None:
+        now = int(time.time())
+    selected = [
+        Device(alias=device.get("alias"), dongle_id=device["dongle_id"])
+        for device in devices
+        if is_owned_online_device(device, now=now)
+    ]
+    selected.sort(key=lambda device: ((device.alias or "").lower(), device.dongle_id))
+    return selected
+
+
+def list_routes_for_local_date(api: CommaApi, dongle_id: str, target_date: date, tz: ZoneInfo) -> list[Route]:
+    routes: list[Route] = []
+    created_before: int | None = None
+
+    for _ in range(10):
+        batch = api.get_routes(dongle_id, created_before=created_before)
+        if not batch:
+            break
+        for item in batch:
+            start_local = parse_route_start_local(item.get("start_time"), tz)
+            if start_local is None:
+                route_date = datetime.now(tz).date()
+            else:
+                route_date = start_local.date()
+            if route_date == target_date:
+                routes.append(
+                    Route(
+                        fullname=item["fullname"],
+                        route_id=route_id_from_fullname(item["fullname"]),
+                        start_time=item.get("start_time"),
+                        maxqlog=item.get("maxqlog", 0),
+                        procqlog=item.get("procqlog"),
+                        url=item["url"],
+                    )
+                )
+        created_before = batch[-1]["create_time"]
+        oldest_local = parse_route_start_local(batch[-1].get("start_time"), tz)
+        if oldest_local is not None and oldest_local.date() < target_date:
+            break
+
+    routes.sort(key=lambda route: parse_route_start_local(route.start_time, tz) or datetime.max.replace(tzinfo=tz))
+    return routes
+
+
+def parsed_segment_upper_bound(route: Route) -> int:
+    if route.procqlog is None:
+        return route.maxqlog
+    return max(0, min(route.procqlog, route.maxqlog))
+
+
+def bookmarked_segments(api: CommaApi, route: Route) -> list[int]:
+    segments: set[int] = set()
+    for seg in range(parsed_segment_upper_bound(route) + 1):
+        events = api.get_events(route.url, seg)
+        for event in events:
+            if event.get("type") not in BOOKMARK_EVENT_TYPES:
+                continue
+            route_offset_millis = int(event["route_offset_millis"])
+            segments.add(route_offset_millis // 60000)
+    return sorted(segments)
+
+
+def expand_segments(bookmarked: Iterable[int], *, previous_segments: int, next_segments: int, max_segment: int) -> list[int]:
+    expanded: set[int] = set()
+    for segment in bookmarked:
+        start = max(0, segment - previous_segments)
+        end = min(max_segment, segment + next_segments)
+        expanded.update(range(start, end + 1))
+    return sorted(expanded)
+
+
+def normalize_uploaded_paths(filelist: dict[str, list[str]]) -> set[str]:
+    uploaded: set[str] = set()
+    for urls in filelist.values():
+        for url in urls:
+            parts = url.split("?")[0].split("/")
+            if len(parts) < 3:
+                continue
+            route_id = parts[-3]
+            segment = parts[-2]
+            filename = parts[-1]
+            uploaded.add(f"{route_id}--{segment}/{filename}")
+    return uploaded
+
+
+def normalize_queue_paths(online_queue: list[dict[str, Any]], offline_queue: list[dict[str, Any]]) -> set[str]:
+    queued: set[str] = set()
+
+    for item in online_queue:
+        raw_path = item.get("path", "")
+        if not raw_path:
+            continue
+        path = Path(raw_path)
+        segment_dir = path.parent.name
+        if not segment_dir:
+            continue
+        queued.add(f"{segment_dir}/{path.name}")
+
+    for item in offline_queue:
+        if item.get("method") != "uploadFilesToUrls":
+            continue
+        params = item.get("params") or {}
+        for file_data in params.get("files_data", []):
+            fn = file_data.get("fn")
+            if fn:
+                queued.add(fn)
+
+    return queued
+
+
+def normalize_online_queue_item_path(item: dict[str, Any]) -> str | None:
+    raw_path = item.get("path", "")
+    if not raw_path:
+        return None
+    path = Path(raw_path)
+    segment_dir = path.parent.name
+    if not segment_dir:
+        return None
+    return f"{segment_dir}/{path.name}"
+
+
+def generate_candidate_paths(route: Route, segments: Iterable[int], file_types: Iterable[str]) -> list[str]:
+    candidates: list[str] = []
+    for segment in segments:
+        for file_type in file_types:
+            for filename in FILE_TYPE_NAMES[file_type]:
+                candidates.append(f"{route.route_id}--{segment}/{filename}")
+    return candidates
+
+
+def request_uploads(api: CommaApi, dongle_id: str, paths: list[str]) -> dict[str, Any]:
+    upload_metadata = api.request_upload_urls(dongle_id, paths)
+    files = [
+        UploadFile(file_path=path, url=metadata["url"], headers=metadata["headers"])
+        for path, metadata in zip(paths, upload_metadata, strict=True)
+    ]
+    payload = {
+        "files_data": [
+            {
+                "allow_cellular": False,
+                "fn": file.file_path,
+                "headers": file.headers,
+                "priority": 1,
+                "url": file.url,
+            }
+            for file in files
+        ]
+    }
+    return api.athena_call(dongle_id, "uploadFilesToUrls", payload)
+
+
+def scan_once(
+    api: CommaApi,
+    *,
+    device_alias: str,
+    target_date: date,
+    tz: ZoneInfo,
+    previous_segments: int,
+    next_segments: int,
+    file_types: list[str],
+    exclusive_bookmark_priority: bool,
+) -> ScanOutcome:
+    bookmarks_found = False
+    uploads_queued = False
+    all_bookmarked_files_satisfied = True
+    queue_cleared = False
+    devices = select_devices(api.get_devices(), device_alias or None)
+    print(f"[{datetime.now(tz).isoformat()}] Watching {len(devices)} device(s) on {target_date.isoformat()}")
+    if not devices:
+        return ScanOutcome(bookmarks_found=False, uploads_queued=False, all_bookmarked_files_satisfied=False, queue_cleared=False)
+
+    any_routes_found = False
+    for device in devices:
+        print(f"Device {device.alias or device.dongle_id} ({device.dongle_id})")
+        routes = list_routes_for_local_date(api, device.dongle_id, target_date, tz)
+        print(f"Found {len(routes)} route(s) for target date")
+        if not routes:
+            continue
+        any_routes_found = True
+
+        online_queue = api.athena_call(device.dongle_id, "listUploadQueue", {}).get("result", [])
+        offline_queue = api.get_athena_offline_queue(device.dongle_id)
+        queued_paths = normalize_queue_paths(online_queue, offline_queue)
+        target_paths: set[str] = set()
+
+        device_bookmarks_found = False
+        for route in routes:
+            route_detail = api.get_route(route.fullname)
+            hydrated_route = Route(
+                fullname=route.fullname,
+                route_id=route.route_id,
+                start_time=route_detail.get("start_time"),
+                maxqlog=route_detail.get("maxqlog", route.maxqlog),
+                procqlog=route_detail.get("procqlog", route.procqlog),
+                url=route_detail.get("url", route.url),
+            )
+            start_local = parse_route_start_local(hydrated_route.start_time, tz)
+            route_files = api.get_route_files(hydrated_route.fullname)
+            qlog_count = len(route_files.get("qlogs", []))
+            parsed_upper_bound = parsed_segment_upper_bound(hydrated_route)
+            print(
+                f"Inspecting {hydrated_route.fullname} start={start_local.isoformat() if start_local else 'unknown'} "
+                f"maxqlog={hydrated_route.maxqlog} procqlog={hydrated_route.procqlog} qlogs={qlog_count}"
+            )
+            if parsed_upper_bound < hydrated_route.maxqlog:
+                print(f"Waiting for parsed qlogs: scanning segments 0..{parsed_upper_bound} so far")
+            bookmark_segments = bookmarked_segments(api, hydrated_route)
+            print(f"Bookmarked segments: {bookmark_segments}")
+            if not bookmark_segments:
+                continue
+
+            bookmarks_found = True
+            device_bookmarks_found = True
+            target_segments = expand_segments(
+                bookmark_segments,
+                previous_segments=previous_segments,
+                next_segments=next_segments,
+                max_segment=hydrated_route.maxqlog,
+            )
+            print(f"Expanded segment window: {target_segments}")
+
+            uploaded_paths = normalize_uploaded_paths(route_files)
+            desired_paths = generate_candidate_paths(hydrated_route, target_segments, file_types)
+            target_paths.update(desired_paths)
+            missing_paths = [path for path in desired_paths if path not in uploaded_paths and path not in queued_paths]
+            print(
+                f"Desired files={len(desired_paths)} uploaded={len(uploaded_paths)} queued={len(queued_paths)} missing={len(missing_paths)}"
+            )
+            if not missing_paths:
+                print("Bookmarked route is already uploaded or queued.")
+                continue
+
+            response = request_uploads(api, device.dongle_id, missing_paths)
+            print("Queued upload request:")
+            print(json.dumps(response, indent=2))
+            queued_paths.update(missing_paths)
+            uploads_queued = True
+            all_bookmarked_files_satisfied = False
+
+        if exclusive_bookmark_priority:
+            if device_bookmarks_found:
+                cancel_ids = [
+                    item["id"]
+                    for item in online_queue
+                    if item.get("id") and normalize_online_queue_item_path(item) not in target_paths
+                ]
+                if cancel_ids:
+                    response = api.cancel_uploads(device.dongle_id, cancel_ids)
+                    print(f"Canceled {len(cancel_ids)} non-bookmark queue item(s):")
+                    print(json.dumps(response, indent=2))
+                    queue_cleared = True
+            else:
+                cancel_ids = [item["id"] for item in online_queue if item.get("id")]
+                if cancel_ids:
+                    response = api.cancel_uploads(device.dongle_id, cancel_ids)
+                    print(f"Canceled {len(cancel_ids)} queue item(s) while waiting for bookmarks:")
+                    print(json.dumps(response, indent=2))
+                    queue_cleared = True
+
+    if not any_routes_found or not bookmarks_found:
+        all_bookmarked_files_satisfied = False
+    return ScanOutcome(
+        bookmarks_found=bookmarks_found,
+        uploads_queued=uploads_queued,
+        all_bookmarked_files_satisfied=all_bookmarked_files_satisfied,
+        queue_cleared=queue_cleared,
+    )
+
+
+def main() -> int:
+    load_dotenv()
+    args = parse_args()
+    if not args.jwt_token:
+        raise SystemExit("Missing JWT token. Set COMMA_JWT or pass --jwt-token.")
+
+    tz = ZoneInfo(args.timezone)
+    target_date = local_date_from_arg(args.date, tz)
+    api = CommaApi(args.jwt_token)
+
+    start_time = time.monotonic()
+    outcome = ScanOutcome(bookmarks_found=False, uploads_queued=False, all_bookmarked_files_satisfied=False, queue_cleared=False)
+    while True:
+        try:
+            outcome = scan_once(
+                api,
+                device_alias=args.device_alias,
+                target_date=target_date,
+                tz=tz,
+                previous_segments=args.previous_segments,
+                next_segments=args.next_segments,
+                file_types=args.file_types,
+                exclusive_bookmark_priority=args.exclusive_bookmark_priority,
+            )
+            if args.exit_when_satisfied and outcome.bookmarks_found and (
+                outcome.uploads_queued or outcome.all_bookmarked_files_satisfied
+            ):
+                print("Bookmarks found and upload work is queued or already complete. Exiting watcher.")
+                return 0
+        except Exception as exc:
+            print(f"Watcher error: {exc}")
+
+        if args.once:
+            return 0 if outcome.bookmarks_found and (outcome.uploads_queued or outcome.all_bookmarked_files_satisfied) else 1
+        if args.timeout_seconds > 0 and time.monotonic() - start_time >= args.timeout_seconds:
+            print("Timed out waiting for bookmarked segments.")
+            return 1
+        print(f"Sleeping for {args.poll_seconds} seconds")
+        time.sleep(args.poll_seconds)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/renderers/big_ui_engine.py
+++ b/renderers/big_ui_engine.py
@@ -726,9 +726,9 @@ def _model_commit_from_github_api(source_commit: object, remote: object) -> tupl
 
 
 def resolve_model_commit_metadata(source_commit: object, remote: object) -> dict[str, str]:
-    resolved = _model_commit_from_local_git(source_commit)
+    resolved = _model_commit_from_github_api(source_commit, remote)
     if resolved is None:
-        resolved = _model_commit_from_github_api(source_commit, remote)
+        resolved = _model_commit_from_local_git(source_commit)
     if resolved is None:
         return {}
     model_commit, model_commit_title = resolved

--- a/tests/test_big_ui_engine.py
+++ b/tests/test_big_ui_engine.py
@@ -320,7 +320,26 @@ def test_ui_alt_dates_text_uses_no_gps_fallback_when_clip_start_missing() -> Non
     )
 
 
-def test_resolve_model_commit_metadata_uses_local_git(monkeypatch) -> None:
+def test_resolve_model_commit_metadata_prefers_github_over_stale_local_git(monkeypatch) -> None:
+    monkeypatch.setattr(
+        big_ui_engine,
+        "_model_commit_from_github_api",
+        lambda *_args: ("4988a62b", 'Revert "POP model (#37727)" (#37871)'),
+    )
+    monkeypatch.setattr(
+        big_ui_engine,
+        "_model_commit_from_local_git",
+        lambda *_args: ("61f7c7ea", "use vendored xvfb (#37934)"),
+    )
+
+    assert big_ui_engine.resolve_model_commit_metadata("ab43fd13", "github.com/commaai/openpilot") == {
+        "model_commit": "4988a62b",
+        "model_commit_title": 'Revert "POP model (#37727)" (#37871)',
+    }
+
+
+def test_resolve_model_commit_metadata_falls_back_to_local_git(monkeypatch) -> None:
+    monkeypatch.setattr(big_ui_engine, "_model_commit_from_github_api", lambda *_args: None)
     monkeypatch.setattr(big_ui_engine, "_find_openpilot_checkout_root", lambda: big_ui_engine.REPO_ROOT)
     monkeypatch.setattr(
         big_ui_engine,

--- a/tests/test_comma_watch.py
+++ b/tests/test_comma_watch.py
@@ -1,12 +1,10 @@
-from datetime import date, datetime
-from zoneinfo import ZoneInfo
-
 from comma_watch import (
     Device,
+    generate_candidate_paths,
     is_owned_online_device,
+    prioritize_segments,
     Route,
     expand_segments,
-    local_date_from_arg,
     normalize_online_queue_item_path,
     normalize_queue_paths,
     normalize_uploaded_paths,
@@ -17,6 +15,10 @@ from comma_watch import (
 
 def test_expand_segments_clamps_route_bounds() -> None:
     assert expand_segments([0, 5], previous_segments=3, next_segments=1, max_segment=6) == [0, 1, 2, 3, 4, 5, 6]
+
+
+def test_prioritize_segments_radiates_out_from_bookmark() -> None:
+    assert prioritize_segments([5], previous_segments=3, next_segments=1, max_segment=6) == [5, 4, 6, 3, 2]
 
 
 def test_normalize_uploaded_paths_extracts_route_segment_and_filename() -> None:
@@ -50,13 +52,6 @@ def test_normalize_queue_paths_handles_online_and_offline_shapes() -> None:
     }
 
 
-def test_local_date_from_arg_today_uses_timezone_today() -> None:
-    tz = ZoneInfo("America/Los_Angeles")
-    today = datetime.now(tz).date()
-    assert local_date_from_arg("today", tz) == today
-    assert local_date_from_arg(today.isoformat(), tz) == date.fromisoformat(today.isoformat())
-
-
 def test_normalize_online_queue_item_path_extracts_segment_dir_and_filename() -> None:
     item = {"path": "/data/media/0/realdata/0000026f--c5469f881d--2/fcamera.hevc"}
     assert normalize_online_queue_item_path(item) == "0000026f--c5469f881d--2/fcamera.hevc"
@@ -67,11 +62,28 @@ def test_parsed_segment_upper_bound_clamps_to_available_segments() -> None:
         fullname="fde53c3c109fb4c0|0000026f--c5469f881d",
         route_id="0000026f--c5469f881d",
         start_time="2026-03-28T04:59:16",
+        end_time="2026-03-28T05:19:16",
         maxqlog=20,
         procqlog=17,
         url="https://example.test/route",
     )
     assert parsed_segment_upper_bound(route) == 17
+
+
+def test_generate_candidate_paths_requests_rlog_zst_only() -> None:
+    route = Route(
+        fullname="fde53c3c109fb4c0|0000026f--c5469f881d",
+        route_id="0000026f--c5469f881d",
+        start_time="2026-03-28T04:59:16",
+        end_time="2026-03-28T05:19:16",
+        maxqlog=20,
+        procqlog=20,
+        url="https://example.test/route",
+    )
+    assert generate_candidate_paths(route, [2], ["cameras", "logs"]) == [
+        "0000026f--c5469f881d--2/fcamera.hevc",
+        "0000026f--c5469f881d--2/rlog.zst",
+    ]
 
 
 def test_select_devices_defaults_to_owned_online_devices() -> None:

--- a/tests/test_comma_watch.py
+++ b/tests/test_comma_watch.py
@@ -1,7 +1,10 @@
 from datetime import datetime
 
 from tools.comma_watch import (
+    annotate_queue_entries,
     athena_enqueue_order,
+    build_route_file_inventory,
+    build_incident_windows,
     categorize_segment_events,
     combine_bookmark_route_fill_segments,
     combine_priority_segments,
@@ -23,8 +26,12 @@ from tools.comma_watch import (
     normalize_online_queue_item_path,
     normalize_queue_paths,
     normalize_uploaded_paths,
+    parse_segment_path,
     parsed_segment_upper_bound,
+    QueueEntry,
+    route_segment_rows,
     select_devices,
+    summarize_online_queue,
     should_clear_queue_while_waiting,
     target_queue_refresh_needed,
 )
@@ -225,6 +232,30 @@ def test_normalize_uploaded_paths_extracts_route_segment_and_filename() -> None:
     }
 
 
+def test_build_route_file_inventory_tracks_low_and_high_quality_files() -> None:
+    filelist = {
+        "cameras": [
+            "https://blob.test/fde53c3c109fb4c0/0000026f--c5469f881d/2/fcamera.hevc?sig=x",
+        ],
+        "qlogs": [
+            "https://blob.test/fde53c3c109fb4c0/0000026f--c5469f881d/2/qlog.zst?sig=x",
+        ],
+        "qcameras": [
+            "https://blob.test/fde53c3c109fb4c0/0000026f--c5469f881d/2/qcamera.ts?sig=x",
+        ],
+    }
+    assert build_route_file_inventory(filelist) == {
+        ("0000026f--c5469f881d", 2): {
+            "fcamera": True,
+            "rlog": False,
+            "ecamera": False,
+            "dcamera": False,
+            "qcamera": True,
+            "qlog": True,
+        }
+    }
+
+
 def test_normalize_queue_paths_handles_online_and_offline_shapes() -> None:
     online_queue = [
         {"path": "/data/media/0/realdata/0000026f--c5469f881d--2/fcamera.hevc"},
@@ -255,6 +286,205 @@ def test_ordered_online_queue_paths_preserves_queue_order() -> None:
         "0000026f--c5469f881d--2/fcamera.hevc",
         "0000026f--c5469f881d--1/rlog.zst",
     ]
+
+
+def test_parse_segment_path_splits_route_segment_and_filename() -> None:
+    assert parse_segment_path("0000026f--c5469f881d--2/fcamera.hevc") == (
+        "0000026f--c5469f881d",
+        2,
+        "fcamera.hevc",
+    )
+
+
+def test_summarize_online_queue_and_route_segment_rows_annotate_active_phase() -> None:
+    queue = [
+        {
+            "id": "1",
+            "path": "/data/media/0/realdata/0000026f--c5469f881d--2/fcamera.hevc",
+            "current": True,
+            "progress": 0.5,
+            "retry_count": 1,
+            "priority": 1,
+        }
+    ]
+    entries = summarize_online_queue(queue)
+    assert entries == [
+        QueueEntry(
+            path="0000026f--c5469f881d--2/fcamera.hevc",
+            route_id="0000026f--c5469f881d",
+            segment=2,
+            filename="fcamera.hevc",
+            file_kind="fcamera",
+            current=True,
+            progress=0.5,
+            retry_count=1,
+            priority=1,
+            upload_id="1",
+        )
+    ]
+    route = Route(
+        fullname="fde53c3c109fb4c0|0000026f--c5469f881d",
+        route_id="0000026f--c5469f881d",
+        start_time="2026-03-28T04:59:16",
+        end_time="2026-03-28T05:19:16",
+        maxqlog=3,
+        procqlog=3,
+        url="https://example.test/route",
+    )
+    rows = route_segment_rows(
+        route=route,
+        route_inventory={("0000026f--c5469f881d", 2): {"fcamera": True, "rlog": False, "ecamera": False, "dcamera": False, "qcamera": True, "qlog": True}},
+        queue_items_by_segment={("0000026f--c5469f881d", 2): entries},
+        segment_phase_lookup={("0000026f--c5469f881d", 2): {"phase": "recent_bookmarks", "rank": 1}},
+        active_phase_targets=[SegmentTarget("0000026f--c5469f881d", 2)],
+        bookmark_segments={2},
+        dm_alert_segments=set(),
+        alert_segments=set(),
+    )
+    assert rows[2]["bookmark"] is True
+    assert rows[2]["phase"] == "recent_bookmarks"
+    assert rows[2]["active_phase_rank"] == 1
+    assert rows[2]["queued_count"] == 1
+    assert rows[2]["active_count"] == 1
+
+
+def test_build_incident_windows_creates_prompt_bookmark_window_and_queue_context() -> None:
+    route = Route(
+        fullname="dongle|0000026f--c5469f881d",
+        route_id="0000026f--c5469f881d",
+        start_time="2026-03-28T04:59:16",
+        end_time="2026-03-28T05:19:16",
+        maxqlog=6,
+        procqlog=6,
+        url="https://example.test/route",
+    )
+    queue_entries = [
+        QueueEntry(
+            path="0000026f--c5469f881d--5/rlog.zst",
+            route_id="0000026f--c5469f881d",
+            segment=5,
+            filename="rlog.zst",
+            file_kind="rlog",
+            current=False,
+            progress=0.0,
+            retry_count=0,
+            priority=1,
+            upload_id="1",
+        )
+    ]
+    windows = build_incident_windows(
+        routes_by_id={route.route_id: route},
+        bookmark_events=[SegmentEvent(route.route_id, 5, datetime.fromisoformat("2026-03-28T05:10:00+00:00"), 6)],
+        dm_alert_events=[],
+        alert_events=[],
+        recent_bookmark_targets=[SegmentTarget(route.route_id, 5), SegmentTarget(route.route_id, 4)],
+        older_bookmark_targets=[],
+        active_phase_name="recent_bookmarks",
+        active_phase_targets=[SegmentTarget(route.route_id, 5), SegmentTarget(route.route_id, 4)],
+        recent_fill_targets=[],
+        older_fill_targets=[],
+        previous_segments=3,
+        next_segments=1,
+        alert_lookback_segments=2,
+        file_types=["cameras", "logs", "ecameras", "dcameras"],
+        route_inventories={route.route_id: {(route.route_id, 5): {"fcamera": True, "rlog": False, "ecamera": False, "dcamera": False, "qcamera": True, "qlog": True}}},
+        queue_items_by_segment={(route.route_id, 5): queue_entries},
+    )
+    assert windows[0]["id"] == "bookmark:0000026f--c5469f881d:5"
+    assert windows[0]["segment_order"] == [5, 4, 6, 3, 2]
+    assert windows[0]["required_file_order"] == ["fcamera", "rlog", "ecamera", "dcamera"]
+    assert windows[0]["phase_membership"] == "recent_bookmarks"
+    assert windows[0]["is_active_phase_window"] is True
+    assert windows[0]["segment_statuses"][0]["queued_file_kinds"] == ["rlog"]
+    assert windows[0]["first_incomplete_segment"]["segment"] == 5
+
+    annotated = annotate_queue_entries(
+        queue_entries,
+        incident_windows=windows,
+        active_phase_name="recent_bookmarks",
+        active_phase_targets=[SegmentTarget(route.route_id, 5)],
+    )
+    assert annotated[0]["incident_window_id"] == "bookmark:0000026f--c5469f881d:5"
+    assert annotated[0]["reason_label"] == "recent bookmark"
+    assert annotated[0]["segment_rank_within_window"] == 1
+    assert annotated[0]["file_rank_within_segment"] == 2
+
+
+def test_build_incident_windows_uses_dm_file_order() -> None:
+    route = Route(
+        fullname="dongle|route-dm",
+        route_id="route-dm",
+        start_time="2026-03-28T04:59:16",
+        end_time="2026-03-28T05:19:16",
+        maxqlog=6,
+        procqlog=6,
+        url="https://example.test/route",
+    )
+    windows = build_incident_windows(
+        routes_by_id={route.route_id: route},
+        bookmark_events=[],
+        dm_alert_events=[SegmentEvent(route.route_id, 4, datetime.fromisoformat("2026-03-28T05:10:00+00:00"), 6, category="dm_alert")],
+        alert_events=[],
+        recent_bookmark_targets=[],
+        older_bookmark_targets=[],
+        active_phase_name="dm_alerts",
+        active_phase_targets=[SegmentTarget(route.route_id, 4)],
+        recent_fill_targets=[],
+        older_fill_targets=[],
+        previous_segments=3,
+        next_segments=1,
+        alert_lookback_segments=2,
+        file_types=["cameras", "logs", "ecameras", "dcameras"],
+        route_inventories={route.route_id: {}},
+        queue_items_by_segment={},
+    )
+    assert windows[0]["category"] == "dm_alert"
+    assert windows[0]["required_file_order"] == ["fcamera", "rlog", "dcamera", "ecamera"]
+    assert windows[0]["segment_order"] == [4, 3, 2]
+
+
+def test_build_incident_windows_marks_bookmark_fill_when_core_window_complete() -> None:
+    route = Route(
+        fullname="dongle|route-fill",
+        route_id="route-fill",
+        start_time="2026-03-28T04:59:16",
+        end_time="2026-03-28T05:19:16",
+        maxqlog=8,
+        procqlog=8,
+        url="https://example.test/route",
+    )
+    inventory = {
+        (route.route_id, segment): {
+            "fcamera": True,
+            "rlog": True,
+            "ecamera": True,
+            "dcamera": True,
+            "qcamera": True,
+            "qlog": True,
+        }
+        for segment in [5, 4, 6, 3, 2]
+    }
+    windows = build_incident_windows(
+        routes_by_id={route.route_id: route},
+        bookmark_events=[SegmentEvent(route.route_id, 5, datetime.fromisoformat("2026-03-28T05:10:00+00:00"), 8)],
+        dm_alert_events=[],
+        alert_events=[],
+        recent_bookmark_targets=[SegmentTarget(route.route_id, 5)],
+        older_bookmark_targets=[],
+        active_phase_name="bookmark_fill_recent",
+        active_phase_targets=[SegmentTarget(route.route_id, 7), SegmentTarget(route.route_id, 8)],
+        recent_fill_targets=[SegmentTarget(route.route_id, 7), SegmentTarget(route.route_id, 8)],
+        older_fill_targets=[],
+        previous_segments=3,
+        next_segments=1,
+        alert_lookback_segments=2,
+        file_types=["cameras", "logs", "ecameras", "dcameras"],
+        route_inventories={route.route_id: inventory},
+        queue_items_by_segment={},
+    )
+    assert windows[0]["phase_membership"] == "bookmark_fill_recent"
+    assert windows[0]["ready_state"] == "complete"
+    assert windows[0]["first_incomplete_segment"] is None
 
 
 def test_desired_pending_paths_skips_uploaded_files() -> None:

--- a/tests/test_comma_watch.py
+++ b/tests/test_comma_watch.py
@@ -1,11 +1,21 @@
-from comma_watch import (
+from datetime import datetime
+
+from tools.comma_watch import (
     categorize_segment_events,
+    combine_bookmark_route_fill_segments,
     combine_priority_segments,
     Device,
+    RouteBookmarkFill,
+    SegmentEvent,
+    SegmentTarget,
+    alert_segments_with_lookback,
+    desired_pending_paths,
     generate_candidate_paths,
     generate_candidate_paths_by_priority,
     is_owned_online_device,
+    ordered_online_queue_paths,
     prioritize_segments,
+    radiate_remaining_route_segments,
     Route,
     expand_segments,
     normalize_online_queue_item_path,
@@ -13,6 +23,8 @@ from comma_watch import (
     normalize_uploaded_paths,
     parsed_segment_upper_bound,
     select_devices,
+    should_clear_queue_while_waiting,
+    target_queue_refresh_needed,
 )
 
 
@@ -24,26 +36,144 @@ def test_prioritize_segments_radiates_out_from_bookmark() -> None:
     assert prioritize_segments([5], previous_segments=3, next_segments=1, max_segment=6) == [5, 4, 6, 3, 2]
 
 
-def test_categorize_segment_events_splits_bookmark_alert_and_override() -> None:
+def test_alert_segments_with_lookback_prioritizes_center_then_history() -> None:
+    assert alert_segments_with_lookback(5, previous_segments=2, max_segment=10) == [5, 4, 3]
+
+
+def test_categorize_segment_events_splits_bookmark_and_alert() -> None:
+    route = Route(
+        fullname="fde53c3c109fb4c0|0000026f--c5469f881d",
+        route_id="0000026f--c5469f881d",
+        start_time="2026-03-28T04:59:16",
+        end_time="2026-03-28T05:19:16",
+        maxqlog=10,
+        procqlog=10,
+        url="https://example.test/route",
+    )
     events = [
         {"type": "user_bookmark", "route_offset_millis": 301000, "data": {}},
         {"type": "state", "route_offset_millis": 361000, "data": {"alertStatus": 1, "state": "enabled"}},
-        {"type": "state", "route_offset_millis": 421000, "data": {"alertStatus": 0, "state": "overriding"}},
     ]
-    assert categorize_segment_events(events, segment=5, max_segment=10) == ({5}, {6}, {7})
+    bookmarks, alerts = categorize_segment_events(route, events, segment=5)
+    assert sorted(bookmarks) == [5]
+    assert sorted(alerts) == [6]
 
 
-def test_combine_priority_segments_orders_bookmarks_then_alerts_then_overrides() -> None:
-    bookmark_window, prioritized_groups = combine_priority_segments(
-        bookmark_segments=[5],
-        alert_segments=[8, 4],
-        override_segments=[7, 3],
+def test_combine_priority_segments_orders_recent_bookmarks_then_older_then_alerts() -> None:
+    bookmark_events = [
+        SegmentEvent("route-a", 1, datetime.fromisoformat("2026-03-28T01:00:00+00:00"), 10),
+        SegmentEvent("route-b", 2, datetime.fromisoformat("2026-03-28T02:00:00+00:00"), 10),
+        SegmentEvent("route-c", 3, datetime.fromisoformat("2026-03-28T03:00:00+00:00"), 10),
+        SegmentEvent("route-d", 4, datetime.fromisoformat("2026-03-28T04:00:00+00:00"), 10),
+        SegmentEvent("route-e", 5, datetime.fromisoformat("2026-03-28T05:00:00+00:00"), 10),
+        SegmentEvent("route-f", 6, datetime.fromisoformat("2026-03-28T06:00:00+00:00"), 10),
+        SegmentEvent("route-g", 7, datetime.fromisoformat("2026-03-28T07:00:00+00:00"), 10),
+    ]
+    alert_events = [
+        SegmentEvent("route-h", 8, datetime.fromisoformat("2026-03-28T08:00:00+00:00"), 10),
+        SegmentEvent("route-i", 9, datetime.fromisoformat("2026-03-28T09:00:00+00:00"), 10),
+    ]
+    prioritized_groups = combine_priority_segments(
+        bookmark_events=bookmark_events,
+        alert_events=alert_events,
         previous_segments=3,
         next_segments=1,
-        max_segment=10,
     )
-    assert bookmark_window == [2, 3, 4, 5, 6]
-    assert prioritized_groups == [[5, 4, 6, 3, 2], [8], [7]]
+    assert prioritized_groups == [
+        [
+            SegmentTarget("route-g", 7),
+            SegmentTarget("route-g", 6),
+            SegmentTarget("route-g", 8),
+            SegmentTarget("route-g", 5),
+            SegmentTarget("route-g", 4),
+            SegmentTarget("route-f", 6),
+            SegmentTarget("route-f", 5),
+            SegmentTarget("route-f", 7),
+            SegmentTarget("route-f", 4),
+            SegmentTarget("route-f", 3),
+            SegmentTarget("route-e", 5),
+            SegmentTarget("route-e", 4),
+            SegmentTarget("route-e", 6),
+            SegmentTarget("route-e", 3),
+            SegmentTarget("route-e", 2),
+            SegmentTarget("route-d", 4),
+            SegmentTarget("route-d", 3),
+            SegmentTarget("route-d", 5),
+            SegmentTarget("route-d", 2),
+            SegmentTarget("route-d", 1),
+            SegmentTarget("route-c", 3),
+            SegmentTarget("route-c", 2),
+            SegmentTarget("route-c", 4),
+            SegmentTarget("route-c", 1),
+            SegmentTarget("route-c", 0),
+        ],
+        [
+            SegmentTarget("route-a", 1),
+            SegmentTarget("route-a", 0),
+            SegmentTarget("route-a", 2),
+            SegmentTarget("route-b", 2),
+            SegmentTarget("route-b", 1),
+            SegmentTarget("route-b", 3),
+            SegmentTarget("route-b", 0),
+        ],
+        [
+            SegmentTarget("route-h", 8),
+            SegmentTarget("route-h", 7),
+            SegmentTarget("route-h", 6),
+            SegmentTarget("route-i", 9),
+            SegmentTarget("route-i", 8),
+            SegmentTarget("route-i", 7),
+        ],
+    ]
+
+
+def test_radiate_remaining_route_segments_expands_out_from_seed_window() -> None:
+    assert radiate_remaining_route_segments(10, {2, 3, 4, 5, 6}) == [1, 7, 0, 8, 9, 10]
+
+
+def test_combine_bookmark_route_fill_segments_fills_bookmarked_routes_after_priority_windows() -> None:
+    bookmark_events = [
+        SegmentEvent("route-old", 5, datetime.fromisoformat("2026-03-28T05:00:00+00:00"), 10),
+        SegmentEvent("route-new", 8, datetime.fromisoformat("2026-03-28T08:00:00+00:00"), 12),
+    ]
+    result = combine_bookmark_route_fill_segments(
+        bookmark_events=bookmark_events,
+        recent_bookmark_targets=[
+            SegmentTarget("route-new", 8),
+            SegmentTarget("route-new", 7),
+            SegmentTarget("route-new", 9),
+            SegmentTarget("route-new", 6),
+            SegmentTarget("route-new", 5),
+        ],
+        older_bookmark_targets=[
+            SegmentTarget("route-old", 5),
+            SegmentTarget("route-old", 4),
+            SegmentTarget("route-old", 6),
+            SegmentTarget("route-old", 3),
+            SegmentTarget("route-old", 2),
+        ],
+        recent_bookmark_count=1,
+    )
+    assert result == RouteBookmarkFill(
+        recent_fill_targets=[
+            SegmentTarget("route-new", 4),
+            SegmentTarget("route-new", 10),
+            SegmentTarget("route-new", 3),
+            SegmentTarget("route-new", 11),
+            SegmentTarget("route-new", 2),
+            SegmentTarget("route-new", 12),
+            SegmentTarget("route-new", 1),
+            SegmentTarget("route-new", 0),
+        ],
+        older_fill_targets=[
+            SegmentTarget("route-old", 1),
+            SegmentTarget("route-old", 7),
+            SegmentTarget("route-old", 0),
+            SegmentTarget("route-old", 8),
+            SegmentTarget("route-old", 9),
+            SegmentTarget("route-old", 10),
+        ],
+    )
 
 
 def test_normalize_uploaded_paths_extracts_route_segment_and_filename() -> None:
@@ -82,6 +212,89 @@ def test_normalize_online_queue_item_path_extracts_segment_dir_and_filename() ->
     assert normalize_online_queue_item_path(item) == "0000026f--c5469f881d--2/fcamera.hevc"
 
 
+def test_ordered_online_queue_paths_preserves_queue_order() -> None:
+    online_queue = [
+        {"path": "/data/media/0/realdata/0000026f--c5469f881d--2/fcamera.hevc"},
+        {"path": "/data/media/0/realdata/0000026f--c5469f881d--1/rlog.zst"},
+    ]
+    assert ordered_online_queue_paths(online_queue) == [
+        "0000026f--c5469f881d--2/fcamera.hevc",
+        "0000026f--c5469f881d--1/rlog.zst",
+    ]
+
+
+def test_desired_pending_paths_skips_uploaded_files() -> None:
+    assert desired_pending_paths(
+        ["a/fcamera.hevc", "a/rlog.zst", "a/ecamera.hevc"],
+        {"a/rlog.zst"},
+    ) == ["a/fcamera.hevc", "a/ecamera.hevc"]
+
+
+def test_target_queue_refresh_needed_when_order_is_wrong() -> None:
+    online_queue = [
+        {"id": "1", "path": "/data/media/0/realdata/route--2/rlog.zst"},
+        {"id": "2", "path": "/data/media/0/realdata/route--2/fcamera.hevc"},
+    ]
+    assert (
+        target_queue_refresh_needed(
+            online_queue,
+            desired_pending_paths=["route--2/fcamera.hevc", "route--2/rlog.zst"],
+            target_paths={"route--2/fcamera.hevc", "route--2/rlog.zst"},
+        )
+        is True
+    )
+
+
+def test_target_queue_refresh_not_needed_when_order_matches() -> None:
+    online_queue = [
+        {"id": "1", "path": "/data/media/0/realdata/route--2/fcamera.hevc"},
+        {"id": "2", "path": "/data/media/0/realdata/route--2/rlog.zst"},
+    ]
+    assert (
+        target_queue_refresh_needed(
+            online_queue,
+            desired_pending_paths=["route--2/fcamera.hevc", "route--2/rlog.zst"],
+            target_paths={"route--2/fcamera.hevc", "route--2/rlog.zst"},
+        )
+        is False
+    )
+
+
+def test_target_queue_refresh_not_needed_when_no_pending_targets_remain() -> None:
+    online_queue = [
+        {"id": "1", "path": "/data/media/0/realdata/other--2/fcamera.hevc"},
+        {"id": "2", "path": "/data/media/0/realdata/other--2/rlog.zst"},
+    ]
+    assert (
+        target_queue_refresh_needed(
+            online_queue,
+            desired_pending_paths=[],
+            target_paths={"route--2/fcamera.hevc", "route--2/rlog.zst"},
+        )
+        is False
+    )
+
+
+def test_should_not_clear_queue_when_priority_targets_are_already_done() -> None:
+    assert (
+        should_clear_queue_while_waiting(
+            prioritized_segments=[SegmentTarget("route--1", 2)],
+            has_pending_priority=False,
+        )
+        is False
+    )
+
+
+def test_should_not_clear_queue_when_no_priority_targets_exist() -> None:
+    assert (
+        should_clear_queue_while_waiting(
+            prioritized_segments=[],
+            has_pending_priority=False,
+        )
+        is False
+    )
+
+
 def test_parsed_segment_upper_bound_clamps_to_available_segments() -> None:
     route = Route(
         fullname="fde53c3c109fb4c0|0000026f--c5469f881d",
@@ -112,16 +325,13 @@ def test_generate_candidate_paths_requests_rlog_zst_only() -> None:
 
 
 def test_generate_candidate_paths_by_priority_orders_file_types_within_each_tier() -> None:
-    route = Route(
-        fullname="fde53c3c109fb4c0|0000026f--c5469f881d",
-        route_id="0000026f--c5469f881d",
-        start_time="2026-03-28T04:59:16",
-        end_time="2026-03-28T05:19:16",
-        maxqlog=20,
-        procqlog=20,
-        url="https://example.test/route",
-    )
-    assert generate_candidate_paths_by_priority(route, [[5, 4], [8]], ["cameras", "logs", "ecameras", "dcameras"]) == [
+    assert generate_candidate_paths_by_priority(
+        [
+            [SegmentTarget("0000026f--c5469f881d", 5), SegmentTarget("0000026f--c5469f881d", 4)],
+            [SegmentTarget("00000270--abc", 8)],
+        ],
+        ["cameras", "logs", "ecameras", "dcameras"],
+    ) == [
         "0000026f--c5469f881d--5/fcamera.hevc",
         "0000026f--c5469f881d--4/fcamera.hevc",
         "0000026f--c5469f881d--5/rlog.zst",
@@ -130,10 +340,10 @@ def test_generate_candidate_paths_by_priority_orders_file_types_within_each_tier
         "0000026f--c5469f881d--4/ecamera.hevc",
         "0000026f--c5469f881d--5/dcamera.hevc",
         "0000026f--c5469f881d--4/dcamera.hevc",
-        "0000026f--c5469f881d--8/fcamera.hevc",
-        "0000026f--c5469f881d--8/rlog.zst",
-        "0000026f--c5469f881d--8/ecamera.hevc",
-        "0000026f--c5469f881d--8/dcamera.hevc",
+        "00000270--abc--8/fcamera.hevc",
+        "00000270--abc--8/rlog.zst",
+        "00000270--abc--8/ecamera.hevc",
+        "00000270--abc--8/dcamera.hevc",
     ]
 
 

--- a/tests/test_comma_watch.py
+++ b/tests/test_comma_watch.py
@@ -14,9 +14,11 @@ from tools.comma_watch import (
     SegmentTarget,
     alert_segments_with_lookback,
     desired_pending_paths,
+    desired_path_priorities,
     generate_candidate_paths,
     generate_candidate_paths_by_priority,
     is_owned_online_device,
+    is_preserved_queue_entry,
     is_dm_alert_event,
     ordered_online_queue_paths,
     prioritize_segments,
@@ -34,6 +36,7 @@ from tools.comma_watch import (
     summarize_online_queue,
     should_clear_queue_while_waiting,
     target_queue_refresh_needed,
+    watcher_priority_for_index,
 )
 
 
@@ -494,69 +497,158 @@ def test_desired_pending_paths_skips_uploaded_files() -> None:
     ) == ["a/fcamera.hevc", "a/ecamera.hevc"]
 
 
-def test_target_queue_refresh_needed_when_order_is_wrong() -> None:
-    online_queue = [
-        {"id": "1", "path": "/data/media/0/realdata/route--2/fcamera.hevc"},
-        {"id": "2", "path": "/data/media/0/realdata/route--2/rlog.zst"},
+def test_target_queue_refresh_needed_when_priority_is_wrong() -> None:
+    queue_entries = [
+        QueueEntry(
+            path="route--2/fcamera.hevc",
+            route_id="route",
+            segment=2,
+            filename="fcamera.hevc",
+            file_kind="fcamera",
+            current=False,
+            progress=0.0,
+            retry_count=0,
+            priority=99,
+            upload_id="1",
+        ),
+        QueueEntry(
+            path="route--2/rlog.zst",
+            route_id="route",
+            segment=2,
+            filename="rlog.zst",
+            file_kind="rlog",
+            current=False,
+            progress=0.0,
+            retry_count=0,
+            priority=99,
+            upload_id="2",
+        ),
     ]
     assert (
         target_queue_refresh_needed(
-            online_queue,
-            desired_pending_paths=["route--2/fcamera.hevc", "route--2/rlog.zst"],
-            missing_paths=["route--2/fcamera.hevc"],
-            target_paths={"route--2/fcamera.hevc", "route--2/rlog.zst"},
+            queue_entries,
+            desired_priorities={
+                "route--2/fcamera.hevc": 0,
+                "route--2/rlog.zst": 1,
+            },
         )
         is True
     )
 
 
-def test_target_queue_refresh_not_needed_when_order_matches() -> None:
-    online_queue = [
-        {"id": "1", "path": "/data/media/0/realdata/lower--1/fcamera.hevc"},
-        {"id": "2", "path": "/data/media/0/realdata/route--2/rlog.zst"},
-        {"id": "3", "path": "/data/media/0/realdata/route--2/fcamera.hevc"},
+def test_target_queue_refresh_not_needed_when_priority_matches() -> None:
+    queue_entries = [
+        QueueEntry(
+            path="route--2/rlog.zst",
+            route_id="route",
+            segment=2,
+            filename="rlog.zst",
+            file_kind="rlog",
+            current=False,
+            progress=0.0,
+            retry_count=0,
+            priority=1,
+            upload_id="2",
+        ),
+        QueueEntry(
+            path="route--2/fcamera.hevc",
+            route_id="route",
+            segment=2,
+            filename="fcamera.hevc",
+            file_kind="fcamera",
+            current=False,
+            progress=0.0,
+            retry_count=0,
+            priority=0,
+            upload_id="3",
+        ),
     ]
     assert (
         target_queue_refresh_needed(
-            online_queue,
-            desired_pending_paths=["route--2/fcamera.hevc", "route--2/rlog.zst"],
-            missing_paths=["route--2/fcamera.hevc"],
-            target_paths={"route--2/fcamera.hevc", "route--2/rlog.zst"},
+            queue_entries,
+            desired_priorities={
+                "route--2/fcamera.hevc": 0,
+                "route--2/rlog.zst": 1,
+            },
         )
         is False
     )
 
 
 def test_target_queue_refresh_not_needed_when_no_pending_targets_remain() -> None:
-    online_queue = [
-        {"id": "1", "path": "/data/media/0/realdata/other--2/fcamera.hevc"},
-        {"id": "2", "path": "/data/media/0/realdata/other--2/rlog.zst"},
+    queue_entries = [
+        QueueEntry(
+            path="other--2/fcamera.hevc",
+            route_id="other",
+            segment=2,
+            filename="fcamera.hevc",
+            file_kind="fcamera",
+            current=False,
+            progress=0.0,
+            retry_count=0,
+            priority=99,
+            upload_id="1",
+        ),
+        QueueEntry(
+            path="other--2/rlog.zst",
+            route_id="other",
+            segment=2,
+            filename="rlog.zst",
+            file_kind="rlog",
+            current=False,
+            progress=0.0,
+            retry_count=0,
+            priority=99,
+            upload_id="2",
+        ),
     ]
     assert (
         target_queue_refresh_needed(
-            online_queue,
-            desired_pending_paths=[],
-            missing_paths=[],
-            target_paths={"route--2/fcamera.hevc", "route--2/rlog.zst"},
+            queue_entries,
+            desired_priorities={},
         )
         is False
     )
 
 
-def test_target_queue_refresh_not_needed_when_all_desired_paths_are_already_queued() -> None:
-    online_queue = [
-        {"id": "1", "path": "/data/media/0/realdata/route--2/rlog.zst"},
-        {"id": "2", "path": "/data/media/0/realdata/route--2/fcamera.hevc"},
-    ]
-    assert (
-        target_queue_refresh_needed(
-            online_queue,
-            desired_pending_paths=["route--2/fcamera.hevc", "route--2/rlog.zst"],
-            missing_paths=[],
-            target_paths={"route--2/fcamera.hevc", "route--2/rlog.zst"},
+def test_desired_path_priorities_follow_phase_bands() -> None:
+    assert desired_path_priorities("recent_bookmarks", ["a", "b", "c"]) == {
+        "a": 0,
+        "b": 1,
+        "c": 2,
+    }
+    assert watcher_priority_for_index("bookmark_fill_recent", 50) == 98
+
+
+def test_is_preserved_queue_entry_marks_low_quality_files() -> None:
+    assert is_preserved_queue_entry(
+        QueueEntry(
+            path="route--2/qlog.zst",
+            route_id="route",
+            segment=2,
+            filename="qlog.zst",
+            file_kind="qlog",
+            current=False,
+            progress=0.0,
+            retry_count=0,
+            priority=99,
+            upload_id="1",
         )
-        is False
-    )
+    ) is True
+    assert is_preserved_queue_entry(
+        QueueEntry(
+            path="route--2/fcamera.hevc",
+            route_id="route",
+            segment=2,
+            filename="fcamera.hevc",
+            file_kind="fcamera",
+            current=False,
+            progress=0.0,
+            retry_count=0,
+            priority=99,
+            upload_id="2",
+        )
+    ) is False
 
 
 def test_should_not_clear_queue_when_priority_targets_are_already_done() -> None:

--- a/tests/test_comma_watch.py
+++ b/tests/test_comma_watch.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from tools.comma_watch import (
+    athena_enqueue_order,
     categorize_segment_events,
     combine_bookmark_route_fill_segments,
     combine_priority_segments,
@@ -13,6 +14,7 @@ from tools.comma_watch import (
     generate_candidate_paths,
     generate_candidate_paths_by_priority,
     is_owned_online_device,
+    is_dm_alert_event,
     ordered_online_queue_paths,
     prioritize_segments,
     radiate_remaining_route_segments,
@@ -54,9 +56,38 @@ def test_categorize_segment_events_splits_bookmark_and_alert() -> None:
         {"type": "user_bookmark", "route_offset_millis": 301000, "data": {}},
         {"type": "state", "route_offset_millis": 361000, "data": {"alertStatus": 1, "state": "enabled"}},
     ]
-    bookmarks, alerts = categorize_segment_events(route, events, segment=5)
+    bookmarks, dm_alerts, alerts = categorize_segment_events(route, events, segment=5)
     assert sorted(bookmarks) == [5]
+    assert sorted(dm_alerts) == []
     assert sorted(alerts) == [6]
+
+
+def test_categorize_segment_events_splits_dm_alerts() -> None:
+    route = Route(
+        fullname="fde53c3c109fb4c0|0000026f--c5469f881d",
+        route_id="0000026f--c5469f881d",
+        start_time="2026-03-28T04:59:16",
+        end_time="2026-03-28T05:19:16",
+        maxqlog=10,
+        procqlog=10,
+        url="https://example.test/route",
+    )
+    events = [
+        {
+            "type": "state",
+            "route_offset_millis": 361000,
+            "data": {"alertStatus": 1, "alertType": "driverDistracted"},
+        },
+    ]
+    bookmarks, dm_alerts, alerts = categorize_segment_events(route, events, segment=5)
+    assert sorted(bookmarks) == []
+    assert sorted(dm_alerts) == [6]
+    assert sorted(alerts) == []
+
+
+def test_is_dm_alert_event_detects_driver_monitoring_strings() -> None:
+    assert is_dm_alert_event({"data": {"alertType": "driverUnresponsive"}}) is True
+    assert is_dm_alert_event({"data": {"alertType": "controlsUnresponsive"}}) is False
 
 
 def test_combine_priority_segments_orders_recent_bookmarks_then_older_then_alerts() -> None:
@@ -75,6 +106,7 @@ def test_combine_priority_segments_orders_recent_bookmarks_then_older_then_alert
     ]
     prioritized_groups = combine_priority_segments(
         bookmark_events=bookmark_events,
+        dm_alert_events=[],
         alert_events=alert_events,
         previous_segments=3,
         next_segments=1,
@@ -115,6 +147,8 @@ def test_combine_priority_segments_orders_recent_bookmarks_then_older_then_alert
             SegmentTarget("route-b", 1),
             SegmentTarget("route-b", 3),
             SegmentTarget("route-b", 0),
+        ],
+        [
         ],
         [
             SegmentTarget("route-h", 8),
@@ -232,13 +266,14 @@ def test_desired_pending_paths_skips_uploaded_files() -> None:
 
 def test_target_queue_refresh_needed_when_order_is_wrong() -> None:
     online_queue = [
-        {"id": "1", "path": "/data/media/0/realdata/route--2/rlog.zst"},
-        {"id": "2", "path": "/data/media/0/realdata/route--2/fcamera.hevc"},
+        {"id": "1", "path": "/data/media/0/realdata/route--2/fcamera.hevc"},
+        {"id": "2", "path": "/data/media/0/realdata/route--2/rlog.zst"},
     ]
     assert (
         target_queue_refresh_needed(
             online_queue,
             desired_pending_paths=["route--2/fcamera.hevc", "route--2/rlog.zst"],
+            missing_paths=["route--2/fcamera.hevc"],
             target_paths={"route--2/fcamera.hevc", "route--2/rlog.zst"},
         )
         is True
@@ -247,13 +282,15 @@ def test_target_queue_refresh_needed_when_order_is_wrong() -> None:
 
 def test_target_queue_refresh_not_needed_when_order_matches() -> None:
     online_queue = [
-        {"id": "1", "path": "/data/media/0/realdata/route--2/fcamera.hevc"},
+        {"id": "1", "path": "/data/media/0/realdata/lower--1/fcamera.hevc"},
         {"id": "2", "path": "/data/media/0/realdata/route--2/rlog.zst"},
+        {"id": "3", "path": "/data/media/0/realdata/route--2/fcamera.hevc"},
     ]
     assert (
         target_queue_refresh_needed(
             online_queue,
             desired_pending_paths=["route--2/fcamera.hevc", "route--2/rlog.zst"],
+            missing_paths=["route--2/fcamera.hevc"],
             target_paths={"route--2/fcamera.hevc", "route--2/rlog.zst"},
         )
         is False
@@ -269,6 +306,23 @@ def test_target_queue_refresh_not_needed_when_no_pending_targets_remain() -> Non
         target_queue_refresh_needed(
             online_queue,
             desired_pending_paths=[],
+            missing_paths=[],
+            target_paths={"route--2/fcamera.hevc", "route--2/rlog.zst"},
+        )
+        is False
+    )
+
+
+def test_target_queue_refresh_not_needed_when_all_desired_paths_are_already_queued() -> None:
+    online_queue = [
+        {"id": "1", "path": "/data/media/0/realdata/route--2/rlog.zst"},
+        {"id": "2", "path": "/data/media/0/realdata/route--2/fcamera.hevc"},
+    ]
+    assert (
+        target_queue_refresh_needed(
+            online_queue,
+            desired_pending_paths=["route--2/fcamera.hevc", "route--2/rlog.zst"],
+            missing_paths=[],
             target_paths={"route--2/fcamera.hevc", "route--2/rlog.zst"},
         )
         is False
@@ -333,17 +387,65 @@ def test_generate_candidate_paths_by_priority_orders_file_types_within_each_tier
         ["cameras", "logs", "ecameras", "dcameras"],
     ) == [
         "0000026f--c5469f881d--5/fcamera.hevc",
-        "0000026f--c5469f881d--4/fcamera.hevc",
         "0000026f--c5469f881d--5/rlog.zst",
-        "0000026f--c5469f881d--4/rlog.zst",
         "0000026f--c5469f881d--5/ecamera.hevc",
-        "0000026f--c5469f881d--4/ecamera.hevc",
         "0000026f--c5469f881d--5/dcamera.hevc",
+        "0000026f--c5469f881d--4/fcamera.hevc",
+        "0000026f--c5469f881d--4/rlog.zst",
+        "0000026f--c5469f881d--4/ecamera.hevc",
         "0000026f--c5469f881d--4/dcamera.hevc",
         "00000270--abc--8/fcamera.hevc",
         "00000270--abc--8/rlog.zst",
         "00000270--abc--8/ecamera.hevc",
         "00000270--abc--8/dcamera.hevc",
+    ]
+
+
+def test_generate_candidate_paths_by_priority_supports_dm_boost_file_order() -> None:
+    assert generate_candidate_paths_by_priority(
+        [
+            [SegmentTarget("route-bookmark", 5)],
+            [SegmentTarget("route-old-bookmark", 4)],
+            [SegmentTarget("route-dm", 3)],
+            [SegmentTarget("route-alert", 2)],
+        ],
+        [
+            ["cameras", "logs", "ecameras", "dcameras"],
+            ["cameras", "logs", "ecameras", "dcameras"],
+            ["cameras", "logs", "dcameras", "ecameras"],
+            ["cameras", "logs", "ecameras", "dcameras"],
+        ],
+    ) == [
+        "route-bookmark--5/fcamera.hevc",
+        "route-bookmark--5/rlog.zst",
+        "route-bookmark--5/ecamera.hevc",
+        "route-bookmark--5/dcamera.hevc",
+        "route-old-bookmark--4/fcamera.hevc",
+        "route-old-bookmark--4/rlog.zst",
+        "route-old-bookmark--4/ecamera.hevc",
+        "route-old-bookmark--4/dcamera.hevc",
+        "route-dm--3/fcamera.hevc",
+        "route-dm--3/rlog.zst",
+        "route-dm--3/dcamera.hevc",
+        "route-dm--3/ecamera.hevc",
+        "route-alert--2/fcamera.hevc",
+        "route-alert--2/rlog.zst",
+        "route-alert--2/ecamera.hevc",
+        "route-alert--2/dcamera.hevc",
+    ]
+
+
+def test_athena_enqueue_order_reverses_priority_paths_for_tail_first_queue() -> None:
+    assert athena_enqueue_order(
+        [
+            "route--2/fcamera.hevc",
+            "route--2/rlog.zst",
+            "route--1/fcamera.hevc",
+        ]
+    ) == [
+        "route--1/fcamera.hevc",
+        "route--2/rlog.zst",
+        "route--2/fcamera.hevc",
     ]
 
 

--- a/tests/test_comma_watch.py
+++ b/tests/test_comma_watch.py
@@ -1,6 +1,9 @@
 from comma_watch import (
+    categorize_segment_events,
+    combine_priority_segments,
     Device,
     generate_candidate_paths,
+    generate_candidate_paths_by_priority,
     is_owned_online_device,
     prioritize_segments,
     Route,
@@ -19,6 +22,28 @@ def test_expand_segments_clamps_route_bounds() -> None:
 
 def test_prioritize_segments_radiates_out_from_bookmark() -> None:
     assert prioritize_segments([5], previous_segments=3, next_segments=1, max_segment=6) == [5, 4, 6, 3, 2]
+
+
+def test_categorize_segment_events_splits_bookmark_alert_and_override() -> None:
+    events = [
+        {"type": "user_bookmark", "route_offset_millis": 301000, "data": {}},
+        {"type": "state", "route_offset_millis": 361000, "data": {"alertStatus": 1, "state": "enabled"}},
+        {"type": "state", "route_offset_millis": 421000, "data": {"alertStatus": 0, "state": "overriding"}},
+    ]
+    assert categorize_segment_events(events, segment=5, max_segment=10) == ({5}, {6}, {7})
+
+
+def test_combine_priority_segments_orders_bookmarks_then_alerts_then_overrides() -> None:
+    bookmark_window, prioritized_groups = combine_priority_segments(
+        bookmark_segments=[5],
+        alert_segments=[8, 4],
+        override_segments=[7, 3],
+        previous_segments=3,
+        next_segments=1,
+        max_segment=10,
+    )
+    assert bookmark_window == [2, 3, 4, 5, 6]
+    assert prioritized_groups == [[5, 4, 6, 3, 2], [8], [7]]
 
 
 def test_normalize_uploaded_paths_extracts_route_segment_and_filename() -> None:
@@ -83,6 +108,32 @@ def test_generate_candidate_paths_requests_rlog_zst_only() -> None:
     assert generate_candidate_paths(route, [2], ["cameras", "logs"]) == [
         "0000026f--c5469f881d--2/fcamera.hevc",
         "0000026f--c5469f881d--2/rlog.zst",
+    ]
+
+
+def test_generate_candidate_paths_by_priority_orders_file_types_within_each_tier() -> None:
+    route = Route(
+        fullname="fde53c3c109fb4c0|0000026f--c5469f881d",
+        route_id="0000026f--c5469f881d",
+        start_time="2026-03-28T04:59:16",
+        end_time="2026-03-28T05:19:16",
+        maxqlog=20,
+        procqlog=20,
+        url="https://example.test/route",
+    )
+    assert generate_candidate_paths_by_priority(route, [[5, 4], [8]], ["cameras", "logs", "ecameras", "dcameras"]) == [
+        "0000026f--c5469f881d--5/fcamera.hevc",
+        "0000026f--c5469f881d--4/fcamera.hevc",
+        "0000026f--c5469f881d--5/rlog.zst",
+        "0000026f--c5469f881d--4/rlog.zst",
+        "0000026f--c5469f881d--5/ecamera.hevc",
+        "0000026f--c5469f881d--4/ecamera.hevc",
+        "0000026f--c5469f881d--5/dcamera.hevc",
+        "0000026f--c5469f881d--4/dcamera.hevc",
+        "0000026f--c5469f881d--8/fcamera.hevc",
+        "0000026f--c5469f881d--8/rlog.zst",
+        "0000026f--c5469f881d--8/ecamera.hevc",
+        "0000026f--c5469f881d--8/dcamera.hevc",
     ]
 
 

--- a/tests/test_comma_watch.py
+++ b/tests/test_comma_watch.py
@@ -1,0 +1,87 @@
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+from comma_watch import (
+    Device,
+    is_owned_online_device,
+    Route,
+    expand_segments,
+    local_date_from_arg,
+    normalize_online_queue_item_path,
+    normalize_queue_paths,
+    normalize_uploaded_paths,
+    parsed_segment_upper_bound,
+    select_devices,
+)
+
+
+def test_expand_segments_clamps_route_bounds() -> None:
+    assert expand_segments([0, 5], previous_segments=3, next_segments=1, max_segment=6) == [0, 1, 2, 3, 4, 5, 6]
+
+
+def test_normalize_uploaded_paths_extracts_route_segment_and_filename() -> None:
+    filelist = {
+        "cameras": [
+            "https://commadata2.blob.core.windows.net/commadata2/fde53c3c109fb4c0/0000026f--c5469f881d/2/fcamera.hevc?sig=x"
+        ],
+        "logs": [
+            "https://commadata2.blob.core.windows.net/commadata2/fde53c3c109fb4c0/0000026f--c5469f881d/2/rlog.zst?sig=x"
+        ],
+    }
+    assert normalize_uploaded_paths(filelist) == {
+        "0000026f--c5469f881d--2/fcamera.hevc",
+        "0000026f--c5469f881d--2/rlog.zst",
+    }
+
+
+def test_normalize_queue_paths_handles_online_and_offline_shapes() -> None:
+    online_queue = [
+        {"path": "/data/media/0/realdata/0000026f--c5469f881d--2/fcamera.hevc"},
+    ]
+    offline_queue = [
+        {
+            "method": "uploadFilesToUrls",
+            "params": {"files_data": [{"fn": "0000026f--c5469f881d--3/rlog.zst"}]},
+        }
+    ]
+    assert normalize_queue_paths(online_queue, offline_queue) == {
+        "0000026f--c5469f881d--2/fcamera.hevc",
+        "0000026f--c5469f881d--3/rlog.zst",
+    }
+
+
+def test_local_date_from_arg_today_uses_timezone_today() -> None:
+    tz = ZoneInfo("America/Los_Angeles")
+    today = datetime.now(tz).date()
+    assert local_date_from_arg("today", tz) == today
+    assert local_date_from_arg(today.isoformat(), tz) == date.fromisoformat(today.isoformat())
+
+
+def test_normalize_online_queue_item_path_extracts_segment_dir_and_filename() -> None:
+    item = {"path": "/data/media/0/realdata/0000026f--c5469f881d--2/fcamera.hevc"}
+    assert normalize_online_queue_item_path(item) == "0000026f--c5469f881d--2/fcamera.hevc"
+
+
+def test_parsed_segment_upper_bound_clamps_to_available_segments() -> None:
+    route = Route(
+        fullname="fde53c3c109fb4c0|0000026f--c5469f881d",
+        route_id="0000026f--c5469f881d",
+        start_time="2026-03-28T04:59:16",
+        maxqlog=20,
+        procqlog=17,
+        url="https://example.test/route",
+    )
+    assert parsed_segment_upper_bound(route) == 17
+
+
+def test_select_devices_defaults_to_owned_online_devices() -> None:
+    now = 1_000
+    devices = [
+        {"alias": "Mine Online", "dongle_id": "a", "is_owner": True, "last_athena_ping": now},
+        {"alias": "Mine Offline", "dongle_id": "b", "is_owner": True, "last_athena_ping": now - 500},
+        {"alias": "Not Mine", "dongle_id": "c", "is_owner": False, "last_athena_ping": now},
+    ]
+    assert is_owned_online_device(devices[0], now=now) is True
+    assert is_owned_online_device(devices[1], now=now) is False
+    assert is_owned_online_device(devices[2], now=now) is False
+    assert select_devices(devices, "", now=now) == [Device(alias="Mine Online", dongle_id="a")]

--- a/tools/comma_watch.py
+++ b/tools/comma_watch.py
@@ -21,6 +21,8 @@ API_URL = "https://api.comma.ai"
 ATHENA_URL = "https://athena.comma.ai"
 DEFAULT_FILE_TYPES = ("cameras", "logs", "ecameras", "dcameras")
 ONLINE_DEVICE_WINDOW_SECONDS = 120
+RECENT_BOOKMARK_COUNT = 5
+ALERT_LOOKBACK_SEGMENTS = 2
 FILE_TYPE_NAMES = {
     "cameras": ("fcamera.hevc",),
     "dcameras": ("dcamera.hevc",),
@@ -29,7 +31,6 @@ FILE_TYPE_NAMES = {
 }
 BOOKMARK_EVENT_TYPES = {"user_flag", "user_bookmark", "bookmark"}
 USER_PROMPT_ALERT_STATUSES = {1, "1", "userPrompt", "user_prompt"}
-OVERRIDE_STATES = {"overriding", "preEnabled"}
 
 
 @dataclass(frozen=True)
@@ -65,10 +66,29 @@ class ScanOutcome:
 
 
 @dataclass(frozen=True)
-class PrioritySegments:
-    bookmark_segments: list[int]
-    alert_segments: list[int]
-    override_segments: list[int]
+class SegmentEvent:
+    route_id: str
+    segment: int
+    event_time: datetime
+    max_segment: int
+
+
+@dataclass(frozen=True)
+class SegmentTarget:
+    route_id: str
+    segment: int
+
+
+@dataclass(frozen=True)
+class PriorityEvents:
+    bookmark_events: list[SegmentEvent]
+    alert_events: list[SegmentEvent]
+
+
+@dataclass(frozen=True)
+class RouteBookmarkFill:
+    recent_fill_targets: list[SegmentTarget]
+    older_fill_targets: list[SegmentTarget]
 
 
 class CommaApi:
@@ -144,7 +164,7 @@ class CommaApi:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Watch Comma routes for bookmarks, alerts, and overrides and queue high-quality uploads."
+        description="Watch Comma routes for bookmarks and alerts and queue high-quality uploads."
     )
     parser.add_argument(
         "--device-alias",
@@ -198,7 +218,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--exclusive-bookmark-priority",
         action="store_true",
-        help="Keep the upload queue clear until bookmarks/alerts/overrides exist, then keep only those uploads queued.",
+        help="Keep the upload queue clear until bookmarks/alerts exist, then keep only those uploads queued.",
     )
     return parser.parse_args()
 
@@ -206,7 +226,19 @@ def parse_args() -> argparse.Namespace:
 def parse_route_start_local(start_time: str | None, tz: ZoneInfo) -> datetime | None:
     if not start_time:
         return None
-    return datetime.fromisoformat(start_time).replace(tzinfo=timezone.utc).astimezone(tz)
+    start = datetime.fromisoformat(start_time)
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=timezone.utc)
+    return start.astimezone(tz)
+
+
+def parse_route_start_utc(start_time: str | None) -> datetime | None:
+    if not start_time:
+        return None
+    start = datetime.fromisoformat(start_time)
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=timezone.utc)
+    return start.astimezone(timezone.utc)
 
 
 def route_id_from_fullname(fullname: str) -> str:
@@ -292,32 +324,49 @@ def segment_from_event(event: dict[str, Any], *, default_segment: int, max_segme
     return max(0, min(max_segment, segment))
 
 
+def event_time_for_route(route: Route, event: dict[str, Any], *, default_segment: int) -> datetime:
+    route_start = parse_route_start_utc(route.start_time)
+    if route_start is None:
+        return datetime.min.replace(tzinfo=timezone.utc)
+
+    route_offset_millis = event.get("route_offset_millis")
+    if route_offset_millis is None:
+        return route_start + timedelta(minutes=default_segment)
+
+    try:
+        offset = int(route_offset_millis)
+    except (TypeError, ValueError):
+        return route_start + timedelta(minutes=default_segment)
+    return route_start + timedelta(milliseconds=offset)
+
+
 def categorize_segment_events(
-    events: Iterable[dict[str, Any]], *, segment: int, max_segment: int
-) -> tuple[set[int], set[int], set[int]]:
-    bookmarks: set[int] = set()
-    alerts: set[int] = set()
-    overrides: set[int] = set()
+    route: Route, events: Iterable[dict[str, Any]], *, segment: int
+) -> tuple[dict[int, datetime], dict[int, datetime]]:
+    bookmarks: dict[int, datetime] = {}
+    alerts: dict[int, datetime] = {}
 
     for event in events:
-        target_segment = segment_from_event(event, default_segment=segment, max_segment=max_segment)
+        target_segment = segment_from_event(event, default_segment=segment, max_segment=route.maxqlog)
         event_type = event.get("type")
         data = event.get("data") or {}
+        event_time = event_time_for_route(route, event, default_segment=segment)
 
         if event_type in BOOKMARK_EVENT_TYPES:
-            bookmarks.add(target_segment)
+            existing = bookmarks.get(target_segment)
+            if existing is None or event_time > existing:
+                bookmarks[target_segment] = event_time
         if data.get("alertStatus") in USER_PROMPT_ALERT_STATUSES:
-            alerts.add(target_segment)
-        if event_type == "overriding" or data.get("state") in OVERRIDE_STATES:
-            overrides.add(target_segment)
+            existing = alerts.get(target_segment)
+            if existing is None or event_time < existing:
+                alerts[target_segment] = event_time
 
-    return bookmarks, alerts, overrides
+    return bookmarks, alerts
 
 
-def collect_priority_segments(api: CommaApi, route: Route) -> PrioritySegments:
-    bookmark_segments: set[int] = set()
-    alert_segments: set[int] = set()
-    override_segments: set[int] = set()
+def collect_priority_events(api: CommaApi, route: Route) -> PriorityEvents:
+    bookmark_segments: dict[int, datetime] = {}
+    alert_segments: dict[int, datetime] = {}
 
     for seg in range(parsed_segment_upper_bound(route) + 1):
         try:
@@ -325,15 +374,25 @@ def collect_priority_segments(api: CommaApi, route: Route) -> PrioritySegments:
         except requests.RequestException as exc:
             print(f"Skipping events for {route.route_id} seg={seg}: {exc}")
             continue
-        bookmarks, alerts, overrides = categorize_segment_events(events, segment=seg, max_segment=route.maxqlog)
-        bookmark_segments.update(bookmarks)
-        alert_segments.update(alerts)
-        override_segments.update(overrides)
+        bookmarks, alerts = categorize_segment_events(route, events, segment=seg)
+        for target_segment, event_time in bookmarks.items():
+            existing = bookmark_segments.get(target_segment)
+            if existing is None or event_time > existing:
+                bookmark_segments[target_segment] = event_time
+        for target_segment, event_time in alerts.items():
+            existing = alert_segments.get(target_segment)
+            if existing is None or event_time < existing:
+                alert_segments[target_segment] = event_time
 
-    return PrioritySegments(
-        bookmark_segments=sorted(bookmark_segments),
-        alert_segments=sorted(alert_segments),
-        override_segments=sorted(override_segments),
+    return PriorityEvents(
+        bookmark_events=[
+            SegmentEvent(route_id=route.route_id, segment=segment, event_time=event_time, max_segment=route.maxqlog)
+            for segment, event_time in bookmark_segments.items()
+        ],
+        alert_events=[
+            SegmentEvent(route_id=route.route_id, segment=segment, event_time=event_time, max_segment=route.maxqlog)
+            for segment, event_time in alert_segments.items()
+        ],
     )
 
 
@@ -368,45 +427,128 @@ def prioritize_segments(bookmarked: Iterable[int], *, previous_segments: int, ne
     return ordered
 
 
+def alert_segments_with_lookback(segment: int, *, previous_segments: int, max_segment: int) -> list[int]:
+    ordered: list[int] = []
+    for candidate in [segment, *range(segment - 1, segment - previous_segments - 1, -1)]:
+        if 0 <= candidate <= max_segment:
+            ordered.append(candidate)
+    return ordered
+
+
+def dedupe_segment_targets(segment_targets: Iterable[SegmentTarget]) -> list[SegmentTarget]:
+    ordered: list[SegmentTarget] = []
+    seen: set[tuple[str, int]] = set()
+    for target in segment_targets:
+        key = (target.route_id, target.segment)
+        if key in seen:
+            continue
+        seen.add(key)
+        ordered.append(target)
+    return ordered
+
+
 def combine_priority_segments(
     *,
-    bookmark_segments: Iterable[int],
-    alert_segments: Iterable[int],
-    override_segments: Iterable[int],
+    bookmark_events: Iterable[SegmentEvent],
+    alert_events: Iterable[SegmentEvent],
     previous_segments: int,
     next_segments: int,
-    max_segment: int,
-) -> tuple[list[int], list[list[int]]]:
-    bookmark_window = expand_segments(
-        bookmark_segments,
-        previous_segments=previous_segments,
-        next_segments=next_segments,
-        max_segment=max_segment,
+    alert_lookback_segments: int = ALERT_LOOKBACK_SEGMENTS,
+    recent_bookmark_count: int = RECENT_BOOKMARK_COUNT,
+) -> list[list[SegmentTarget]]:
+    bookmark_events_sorted = sorted(bookmark_events, key=lambda event: event.event_time)
+    recent_bookmark_events = list(reversed(bookmark_events_sorted[-recent_bookmark_count:]))
+    older_bookmark_events = bookmark_events_sorted[:-recent_bookmark_count]
+    alert_events_sorted = sorted(alert_events, key=lambda event: event.event_time)
+
+    grouped_targets: list[list[SegmentTarget]] = []
+
+    for bookmark_group in (recent_bookmark_events, older_bookmark_events):
+        targets: list[SegmentTarget] = []
+        for event in bookmark_group:
+            for segment in prioritize_segments(
+                [event.segment],
+                previous_segments=previous_segments,
+                next_segments=next_segments,
+                max_segment=event.max_segment,
+            ):
+                targets.append(SegmentTarget(route_id=event.route_id, segment=segment))
+        grouped_targets.append(dedupe_segment_targets(targets))
+
+    alert_targets: list[SegmentTarget] = []
+    for event in alert_events_sorted:
+        for segment in alert_segments_with_lookback(
+            event.segment,
+            previous_segments=alert_lookback_segments,
+            max_segment=event.max_segment,
+        ):
+            alert_targets.append(SegmentTarget(route_id=event.route_id, segment=segment))
+    grouped_targets.append(dedupe_segment_targets(alert_targets))
+
+    return grouped_targets
+
+
+def unique_route_order(events: Iterable[SegmentEvent]) -> list[str]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for event in events:
+        if event.route_id in seen:
+            continue
+        seen.add(event.route_id)
+        ordered.append(event.route_id)
+    return ordered
+
+
+def radiate_remaining_route_segments(max_segment: int, seeded_segments: Iterable[int]) -> list[int]:
+    seed_set = set(seeded_segments)
+    if not seed_set:
+        return list(range(max_segment + 1))
+
+    remaining = [segment for segment in range(max_segment + 1) if segment not in seed_set]
+    return sorted(
+        remaining,
+        key=lambda segment: (
+            min(abs(segment - seed) for seed in seed_set),
+            segment,
+        ),
     )
-    seen: set[int] = set()
-    grouped_segments: list[list[int]] = []
 
-    bookmark_order = prioritize_segments(
-        bookmark_segments,
-        previous_segments=previous_segments,
-        next_segments=next_segments,
-        max_segment=max_segment,
+
+def combine_bookmark_route_fill_segments(
+    *,
+    bookmark_events: Iterable[SegmentEvent],
+    recent_bookmark_targets: Iterable[SegmentTarget],
+    older_bookmark_targets: Iterable[SegmentTarget],
+    recent_bookmark_count: int = RECENT_BOOKMARK_COUNT,
+) -> RouteBookmarkFill:
+    bookmark_events_sorted = sorted(bookmark_events, key=lambda event: event.event_time)
+    recent_bookmark_events = list(reversed(bookmark_events_sorted[-recent_bookmark_count:]))
+    older_bookmark_events = bookmark_events_sorted[:-recent_bookmark_count]
+
+    route_max_segments: dict[str, int] = {}
+    for event in bookmark_events_sorted:
+        route_max_segments[event.route_id] = event.max_segment
+
+    seeded_targets_by_route: dict[str, set[int]] = {}
+    for target in list(recent_bookmark_targets) + list(older_bookmark_targets):
+        seeded_targets_by_route.setdefault(target.route_id, set()).add(target.segment)
+
+    recent_route_ids = unique_route_order(recent_bookmark_events)
+    older_route_ids = [route_id for route_id in unique_route_order(older_bookmark_events) if route_id not in set(recent_route_ids)]
+
+    def build_fill_targets(route_ids: list[str]) -> list[SegmentTarget]:
+        fill_targets: list[SegmentTarget] = []
+        for route_id in route_ids:
+            seeded_segments = seeded_targets_by_route.get(route_id, set())
+            max_segment = route_max_segments[route_id]
+            for segment in radiate_remaining_route_segments(max_segment, seeded_segments):
+                fill_targets.append(SegmentTarget(route_id=route_id, segment=segment))
+        return fill_targets
+
+    return RouteBookmarkFill(
+        recent_fill_targets=build_fill_targets(recent_route_ids),
+        older_fill_targets=build_fill_targets(older_route_ids),
     )
-    grouped_segments.append([])
-    for segment in bookmark_order:
-        if segment not in seen:
-            seen.add(segment)
-            grouped_segments[-1].append(segment)
-
-    for bucket in (alert_segments, override_segments):
-        grouped_segments.append([])
-        for segment in bucket:
-            if segment < 0 or segment > max_segment or segment in seen:
-                continue
-            seen.add(segment)
-            grouped_segments[-1].append(segment)
-
-    return bookmark_window, grouped_segments
 
 
 def normalize_uploaded_paths(filelist: dict[str, list[str]]) -> set[str]:
@@ -459,6 +601,38 @@ def normalize_online_queue_item_path(item: dict[str, Any]) -> str | None:
     return f"{segment_dir}/{path.name}"
 
 
+def ordered_online_queue_paths(online_queue: list[dict[str, Any]]) -> list[str]:
+    ordered_paths: list[str] = []
+    for item in online_queue:
+        normalized = normalize_online_queue_item_path(item)
+        if normalized is not None:
+            ordered_paths.append(normalized)
+    return ordered_paths
+
+
+def desired_pending_paths(desired_paths: Iterable[str], uploaded_paths: set[str]) -> list[str]:
+    return [path for path in desired_paths if path not in uploaded_paths]
+
+
+def target_queue_refresh_needed(
+    online_queue: list[dict[str, Any]],
+    *,
+    desired_pending_paths: list[str],
+    target_paths: set[str],
+) -> bool:
+    if not desired_pending_paths:
+        return False
+    ordered_paths = ordered_online_queue_paths(online_queue)
+    queued_target_paths = [path for path in ordered_paths if path in target_paths]
+    if queued_target_paths != desired_pending_paths:
+        return True
+    return any(path not in target_paths for path in ordered_paths)
+
+
+def should_clear_queue_while_waiting(*, prioritized_segments: list[SegmentTarget], has_pending_priority: bool) -> bool:
+    return False
+
+
 def generate_candidate_paths(route: Route, segments: Iterable[int], file_types: Iterable[str]) -> list[str]:
     candidates: list[str] = []
     for segment in segments:
@@ -472,7 +646,7 @@ def generate_candidate_paths(route: Route, segments: Iterable[int], file_types: 
 
 
 def generate_candidate_paths_by_priority(
-    route: Route, segment_groups: Iterable[Iterable[int]], file_types: Iterable[str]
+    segment_groups: Iterable[Iterable[SegmentTarget]], file_types: Iterable[str]
 ) -> list[str]:
     candidates: list[str] = []
     for segments in segment_groups:
@@ -480,11 +654,11 @@ def generate_candidate_paths_by_priority(
         for file_type in file_types:
             if file_type == "logs":
                 for segment in segment_list:
-                    candidates.append(f"{route.route_id}--{segment}/rlog.zst")
+                    candidates.append(f"{segment.route_id}--{segment.segment}/rlog.zst")
                 continue
             for segment in segment_list:
                 for filename in FILE_TYPE_NAMES[file_type]:
-                    candidates.append(f"{route.route_id}--{segment}/{filename}")
+                    candidates.append(f"{segment.route_id}--{segment.segment}/{filename}")
     return candidates
 
 
@@ -547,8 +721,10 @@ def scan_once(
         offline_queue = api.get_athena_offline_queue(device.dongle_id)
         queued_paths = normalize_queue_paths(online_queue, offline_queue)
         target_paths: set[str] = set()
+        uploaded_paths: set[str] = set()
+        bookmark_events: list[SegmentEvent] = []
+        alert_events: list[SegmentEvent] = []
 
-        device_targets_found = False
         for route in routes:
             route_detail = api.get_route(route.fullname)
             hydrated_route = Route(
@@ -570,51 +746,104 @@ def scan_once(
             )
             if parsed_upper_bound < hydrated_route.maxqlog:
                 print(f"Waiting for parsed qlogs: scanning segments 0..{parsed_upper_bound} so far")
-            priority_segments = collect_priority_segments(api, hydrated_route)
-            print(f"Bookmarked segments: {priority_segments.bookmark_segments}")
-            print(f"Alert segments: {priority_segments.alert_segments}")
-            print(f"Override segments: {priority_segments.override_segments}")
-            if not (
-                priority_segments.bookmark_segments
-                or priority_segments.alert_segments
-                or priority_segments.override_segments
-            ):
-                continue
+            uploaded_paths.update(normalize_uploaded_paths(route_files))
+            priority_events = collect_priority_events(api, hydrated_route)
+            bookmark_segments = sorted({event.segment for event in priority_events.bookmark_events})
+            alert_segments = sorted({event.segment for event in priority_events.alert_events})
+            print(f"Bookmarked segments: {bookmark_segments}")
+            print(f"Alert segments: {alert_segments}")
+            if priority_events.bookmark_events or priority_events.alert_events:
+                targets_found = True
+            bookmark_events.extend(priority_events.bookmark_events)
+            alert_events.extend(priority_events.alert_events)
 
-            targets_found = True
-            device_targets_found = True
-            bookmark_window, prioritized_segment_groups = combine_priority_segments(
-                bookmark_segments=priority_segments.bookmark_segments,
-                alert_segments=priority_segments.alert_segments,
-                override_segments=priority_segments.override_segments,
-                previous_segments=previous_segments,
-                next_segments=next_segments,
-                max_segment=hydrated_route.maxqlog,
-            )
-            prioritized_segments = [segment for group in prioritized_segment_groups for segment in group]
-            print(f"Expanded bookmark window: {bookmark_window}")
-            print(f"Upload priority order: {prioritized_segments}")
-
-            uploaded_paths = normalize_uploaded_paths(route_files)
-            desired_paths = generate_candidate_paths_by_priority(hydrated_route, prioritized_segment_groups, file_types)
+        prioritized_segment_groups = combine_priority_segments(
+            bookmark_events=bookmark_events,
+            alert_events=alert_events,
+            previous_segments=previous_segments,
+            next_segments=next_segments,
+        )
+        recent_bookmark_targets, older_bookmark_targets, alert_targets = prioritized_segment_groups
+        prioritized_segments = [target for group in prioritized_segment_groups for target in group]
+        print(
+            "Recent bookmark targets:",
+            [f"{target.route_id}:{target.segment}" for target in recent_bookmark_targets],
+        )
+        print(
+            "Older bookmark targets:",
+            [f"{target.route_id}:{target.segment}" for target in older_bookmark_targets],
+        )
+        print(
+            "Alert targets:",
+            [f"{target.route_id}:{target.segment}" for target in alert_targets],
+        )
+        if prioritized_segments:
+            priority_paths = generate_candidate_paths_by_priority(prioritized_segment_groups, file_types)
+            target_paths.update(priority_paths)
+            pending_priority_paths = desired_pending_paths(priority_paths, uploaded_paths)
+            has_pending_priority = bool(pending_priority_paths)
+            fill_phase_groups: list[list[SegmentTarget]] = []
+            if not has_pending_priority:
+                fill_targets = combine_bookmark_route_fill_segments(
+                    bookmark_events=bookmark_events,
+                    recent_bookmark_targets=recent_bookmark_targets,
+                    older_bookmark_targets=older_bookmark_targets,
+                )
+                fill_phase_groups = [fill_targets.recent_fill_targets, fill_targets.older_fill_targets]
+                print(
+                    "Bookmark route fill targets:",
+                    [f"{target.route_id}:{target.segment}" for group in fill_phase_groups for target in group],
+                )
+            desired_paths = priority_paths + generate_candidate_paths_by_priority(fill_phase_groups, file_types)
             target_paths.update(desired_paths)
+            pending_paths = desired_pending_paths(desired_paths, uploaded_paths)
+            has_pending_targets = bool(pending_paths)
             missing_paths = [path for path in desired_paths if path not in uploaded_paths and path not in queued_paths]
+            print(
+                "Global segment priority order:",
+                [f"{target.route_id}:{target.segment}" for target in prioritized_segments],
+            )
             print(
                 f"Desired files={len(desired_paths)} uploaded={len(uploaded_paths)} queued={len(queued_paths)} missing={len(missing_paths)}"
             )
-            if not missing_paths:
-                print("Priority route files are already uploaded or queued.")
-                continue
+            refreshed_queue = False
+            if exclusive_bookmark_priority and target_queue_refresh_needed(
+                online_queue,
+                desired_pending_paths=pending_paths,
+                target_paths=target_paths,
+            ):
+                cancel_ids = [item["id"] for item in online_queue if item.get("id")]
+                if cancel_ids:
+                    response = api.cancel_uploads(device.dongle_id, cancel_ids)
+                    print(f"Canceled {len(cancel_ids)} queue item(s) to rebuild priority order:")
+                    print(json.dumps(response, indent=2))
+                    queue_cleared = True
+                online_queue = []
+                offline_queue = api.get_athena_offline_queue(device.dongle_id)
+                queued_paths = normalize_queue_paths(online_queue, offline_queue)
+                missing_paths = [path for path in desired_paths if path not in uploaded_paths and path not in queued_paths]
+                refreshed_queue = True
 
-            response = request_uploads(api, device.dongle_id, missing_paths)
-            print("Queued upload request:")
-            print(json.dumps(response, indent=2))
-            queued_paths.update(missing_paths)
-            uploads_queued = True
+            if not missing_paths:
+                if refreshed_queue:
+                    print("Priority segment files were already uploaded after queue refresh.")
+                else:
+                    print("Priority segment files are already uploaded or queued.")
+            else:
+                response = request_uploads(api, device.dongle_id, missing_paths)
+                print("Queued upload request:")
+                print(json.dumps(response, indent=2))
+                queued_paths.update(missing_paths)
+                uploads_queued = True
+                all_target_files_satisfied = False
+        else:
+            print("No bookmark or alert targets found in lookback window.")
             all_target_files_satisfied = False
+            has_pending_priority = False
+            has_pending_targets = False
 
         if exclusive_bookmark_priority:
-            if device_targets_found:
+            if prioritized_segments and has_pending_targets:
                 cancel_ids = [
                     item["id"]
                     for item in online_queue
@@ -625,7 +854,10 @@ def scan_once(
                     print(f"Canceled {len(cancel_ids)} non-priority queue item(s):")
                     print(json.dumps(response, indent=2))
                     queue_cleared = True
-            else:
+            elif should_clear_queue_while_waiting(
+                prioritized_segments=prioritized_segments,
+                has_pending_priority=has_pending_targets,
+            ):
                 cancel_ids = [item["id"] for item in online_queue if item.get("id")]
                 if cancel_ids:
                     response = api.cancel_uploads(device.dongle_id, cancel_ids)

--- a/tools/comma_watch.py
+++ b/tools/comma_watch.py
@@ -31,6 +31,15 @@ FILE_TYPE_NAMES = {
 }
 BOOKMARK_EVENT_TYPES = {"user_flag", "user_bookmark", "bookmark"}
 USER_PROMPT_ALERT_STATUSES = {1, "1", "userPrompt", "user_prompt"}
+DM_ALERT_HINTS = (
+    "driver",
+    "distract",
+    "toodistracted",
+    "toounresponsive",
+    "predriverdistracted",
+    "predriverunresponsive",
+    "promptdriver",
+)
 
 
 @dataclass(frozen=True)
@@ -71,6 +80,7 @@ class SegmentEvent:
     segment: int
     event_time: datetime
     max_segment: int
+    category: str = "generic"
 
 
 @dataclass(frozen=True)
@@ -82,6 +92,7 @@ class SegmentTarget:
 @dataclass(frozen=True)
 class PriorityEvents:
     bookmark_events: list[SegmentEvent]
+    dm_alert_events: list[SegmentEvent]
     alert_events: list[SegmentEvent]
 
 
@@ -340,10 +351,25 @@ def event_time_for_route(route: Route, event: dict[str, Any], *, default_segment
     return route_start + timedelta(milliseconds=offset)
 
 
+def is_dm_alert_event(event: dict[str, Any]) -> bool:
+    data = event.get("data") or {}
+    haystacks = (
+        str(event.get("type", "")),
+        str(data.get("alertType", "")),
+        str(data.get("alertText1", "")),
+        str(data.get("alertText2", "")),
+        str(data.get("event", "")),
+        str(data.get("name", "")),
+    )
+    lowered = " ".join(haystacks).lower()
+    return any(hint in lowered for hint in DM_ALERT_HINTS)
+
+
 def categorize_segment_events(
     route: Route, events: Iterable[dict[str, Any]], *, segment: int
-) -> tuple[dict[int, datetime], dict[int, datetime]]:
+) -> tuple[dict[int, datetime], dict[int, datetime], dict[int, datetime]]:
     bookmarks: dict[int, datetime] = {}
+    dm_alerts: dict[int, datetime] = {}
     alerts: dict[int, datetime] = {}
 
     for event in events:
@@ -357,15 +383,17 @@ def categorize_segment_events(
             if existing is None or event_time > existing:
                 bookmarks[target_segment] = event_time
         if data.get("alertStatus") in USER_PROMPT_ALERT_STATUSES:
-            existing = alerts.get(target_segment)
+            target_alerts = dm_alerts if is_dm_alert_event(event) else alerts
+            existing = target_alerts.get(target_segment)
             if existing is None or event_time < existing:
-                alerts[target_segment] = event_time
+                target_alerts[target_segment] = event_time
 
-    return bookmarks, alerts
+    return bookmarks, dm_alerts, alerts
 
 
 def collect_priority_events(api: CommaApi, route: Route) -> PriorityEvents:
     bookmark_segments: dict[int, datetime] = {}
+    dm_alert_segments: dict[int, datetime] = {}
     alert_segments: dict[int, datetime] = {}
 
     for seg in range(parsed_segment_upper_bound(route) + 1):
@@ -374,11 +402,15 @@ def collect_priority_events(api: CommaApi, route: Route) -> PriorityEvents:
         except requests.RequestException as exc:
             print(f"Skipping events for {route.route_id} seg={seg}: {exc}")
             continue
-        bookmarks, alerts = categorize_segment_events(route, events, segment=seg)
+        bookmarks, dm_alerts, alerts = categorize_segment_events(route, events, segment=seg)
         for target_segment, event_time in bookmarks.items():
             existing = bookmark_segments.get(target_segment)
             if existing is None or event_time > existing:
                 bookmark_segments[target_segment] = event_time
+        for target_segment, event_time in dm_alerts.items():
+            existing = dm_alert_segments.get(target_segment)
+            if existing is None or event_time < existing:
+                dm_alert_segments[target_segment] = event_time
         for target_segment, event_time in alerts.items():
             existing = alert_segments.get(target_segment)
             if existing is None or event_time < existing:
@@ -386,11 +418,33 @@ def collect_priority_events(api: CommaApi, route: Route) -> PriorityEvents:
 
     return PriorityEvents(
         bookmark_events=[
-            SegmentEvent(route_id=route.route_id, segment=segment, event_time=event_time, max_segment=route.maxqlog)
+            SegmentEvent(
+                route_id=route.route_id,
+                segment=segment,
+                event_time=event_time,
+                max_segment=route.maxqlog,
+                category="bookmark",
+            )
             for segment, event_time in bookmark_segments.items()
         ],
+        dm_alert_events=[
+            SegmentEvent(
+                route_id=route.route_id,
+                segment=segment,
+                event_time=event_time,
+                max_segment=route.maxqlog,
+                category="dm_alert",
+            )
+            for segment, event_time in dm_alert_segments.items()
+        ],
         alert_events=[
-            SegmentEvent(route_id=route.route_id, segment=segment, event_time=event_time, max_segment=route.maxqlog)
+            SegmentEvent(
+                route_id=route.route_id,
+                segment=segment,
+                event_time=event_time,
+                max_segment=route.maxqlog,
+                category="alert",
+            )
             for segment, event_time in alert_segments.items()
         ],
     )
@@ -450,6 +504,7 @@ def dedupe_segment_targets(segment_targets: Iterable[SegmentTarget]) -> list[Seg
 def combine_priority_segments(
     *,
     bookmark_events: Iterable[SegmentEvent],
+    dm_alert_events: Iterable[SegmentEvent],
     alert_events: Iterable[SegmentEvent],
     previous_segments: int,
     next_segments: int,
@@ -459,6 +514,7 @@ def combine_priority_segments(
     bookmark_events_sorted = sorted(bookmark_events, key=lambda event: event.event_time)
     recent_bookmark_events = list(reversed(bookmark_events_sorted[-recent_bookmark_count:]))
     older_bookmark_events = bookmark_events_sorted[:-recent_bookmark_count]
+    dm_alert_events_sorted = sorted(dm_alert_events, key=lambda event: event.event_time)
     alert_events_sorted = sorted(alert_events, key=lambda event: event.event_time)
 
     grouped_targets: list[list[SegmentTarget]] = []
@@ -474,6 +530,16 @@ def combine_priority_segments(
             ):
                 targets.append(SegmentTarget(route_id=event.route_id, segment=segment))
         grouped_targets.append(dedupe_segment_targets(targets))
+
+    dm_alert_targets: list[SegmentTarget] = []
+    for event in dm_alert_events_sorted:
+        for segment in alert_segments_with_lookback(
+            event.segment,
+            previous_segments=alert_lookback_segments,
+            max_segment=event.max_segment,
+        ):
+            dm_alert_targets.append(SegmentTarget(route_id=event.route_id, segment=segment))
+    grouped_targets.append(dedupe_segment_targets(dm_alert_targets))
 
     alert_targets: list[SegmentTarget] = []
     for event in alert_events_sorted:
@@ -618,15 +684,18 @@ def target_queue_refresh_needed(
     online_queue: list[dict[str, Any]],
     *,
     desired_pending_paths: list[str],
+    missing_paths: list[str],
     target_paths: set[str],
 ) -> bool:
     if not desired_pending_paths:
         return False
+    if not missing_paths:
+        return False
     ordered_paths = ordered_online_queue_paths(online_queue)
-    queued_target_paths = [path for path in ordered_paths if path in target_paths]
-    if queued_target_paths != desired_pending_paths:
+    expected_queue_tail = athena_enqueue_order(desired_pending_paths)
+    if len(ordered_paths) < len(expected_queue_tail):
         return True
-    return any(path not in target_paths for path in ordered_paths)
+    return ordered_paths[-len(expected_queue_tail) :] != expected_queue_tail
 
 
 def should_clear_queue_while_waiting(*, prioritized_segments: list[SegmentTarget], has_pending_priority: bool) -> bool:
@@ -646,27 +715,50 @@ def generate_candidate_paths(route: Route, segments: Iterable[int], file_types: 
 
 
 def generate_candidate_paths_by_priority(
-    segment_groups: Iterable[Iterable[SegmentTarget]], file_types: Iterable[str]
+    segment_groups: Iterable[Iterable[SegmentTarget]], file_types: Iterable[Iterable[str] | str]
 ) -> list[str]:
     candidates: list[str] = []
-    for segments in segment_groups:
+    segment_group_list = [list(group) for group in segment_groups]
+    file_type_groups = list(file_types)
+    if file_type_groups and isinstance(file_type_groups[0], str):
+        file_type_groups = [list(file_type_groups) for _ in segment_group_list]
+
+    for segments, group_file_types in zip(segment_group_list, file_type_groups, strict=True):
         segment_list = list(segments)
-        for file_type in file_types:
-            if file_type == "logs":
-                for segment in segment_list:
+        for segment in segment_list:
+            for file_type in group_file_types:
+                if file_type == "logs":
                     candidates.append(f"{segment.route_id}--{segment.segment}/rlog.zst")
-                continue
-            for segment in segment_list:
+                    continue
                 for filename in FILE_TYPE_NAMES[file_type]:
                     candidates.append(f"{segment.route_id}--{segment.segment}/{filename}")
     return candidates
 
 
+def first_pending_phase(
+    phase_specs: Iterable[tuple[str, list[SegmentTarget], list[str]]],
+    uploaded_paths: set[str],
+) -> tuple[str, list[SegmentTarget], list[str], list[str], list[str]] | None:
+    for phase_name, phase_targets, phase_file_types in phase_specs:
+        if not phase_targets:
+            continue
+        desired_paths = generate_candidate_paths_by_priority([phase_targets], [phase_file_types])
+        pending_paths = desired_pending_paths(desired_paths, uploaded_paths)
+        if pending_paths:
+            return phase_name, phase_targets, phase_file_types, desired_paths, pending_paths
+    return None
+
+
+def athena_enqueue_order(paths: Iterable[str]) -> list[str]:
+    return list(reversed(list(paths)))
+
+
 def request_uploads(api: CommaApi, dongle_id: str, paths: list[str]) -> dict[str, Any]:
-    upload_metadata = api.request_upload_urls(dongle_id, paths)
+    ordered_paths = athena_enqueue_order(paths)
+    upload_metadata = api.request_upload_urls(dongle_id, ordered_paths)
     files = [
         UploadFile(file_path=path, url=metadata["url"], headers=metadata["headers"])
-        for path, metadata in zip(paths, upload_metadata, strict=True)
+        for path, metadata in zip(ordered_paths, upload_metadata, strict=True)
     ]
     payload = {
         "files_data": [
@@ -723,6 +815,7 @@ def scan_once(
         target_paths: set[str] = set()
         uploaded_paths: set[str] = set()
         bookmark_events: list[SegmentEvent] = []
+        dm_alert_events: list[SegmentEvent] = []
         alert_events: list[SegmentEvent] = []
 
         for route in routes:
@@ -749,21 +842,25 @@ def scan_once(
             uploaded_paths.update(normalize_uploaded_paths(route_files))
             priority_events = collect_priority_events(api, hydrated_route)
             bookmark_segments = sorted({event.segment for event in priority_events.bookmark_events})
+            dm_alert_segments = sorted({event.segment for event in priority_events.dm_alert_events})
             alert_segments = sorted({event.segment for event in priority_events.alert_events})
             print(f"Bookmarked segments: {bookmark_segments}")
+            print(f"DM alert segments: {dm_alert_segments}")
             print(f"Alert segments: {alert_segments}")
-            if priority_events.bookmark_events or priority_events.alert_events:
+            if priority_events.bookmark_events or priority_events.dm_alert_events or priority_events.alert_events:
                 targets_found = True
             bookmark_events.extend(priority_events.bookmark_events)
+            dm_alert_events.extend(priority_events.dm_alert_events)
             alert_events.extend(priority_events.alert_events)
 
         prioritized_segment_groups = combine_priority_segments(
             bookmark_events=bookmark_events,
+            dm_alert_events=dm_alert_events,
             alert_events=alert_events,
             previous_segments=previous_segments,
             next_segments=next_segments,
         )
-        recent_bookmark_targets, older_bookmark_targets, alert_targets = prioritized_segment_groups
+        recent_bookmark_targets, older_bookmark_targets, dm_alert_targets, alert_targets = prioritized_segment_groups
         prioritized_segments = [target for group in prioritized_segment_groups for target in group]
         print(
             "Recent bookmark targets:",
@@ -774,35 +871,68 @@ def scan_once(
             [f"{target.route_id}:{target.segment}" for target in older_bookmark_targets],
         )
         print(
+            "DM alert targets:",
+            [f"{target.route_id}:{target.segment}" for target in dm_alert_targets],
+        )
+        print(
             "Alert targets:",
             [f"{target.route_id}:{target.segment}" for target in alert_targets],
         )
         if prioritized_segments:
-            priority_paths = generate_candidate_paths_by_priority(prioritized_segment_groups, file_types)
-            target_paths.update(priority_paths)
-            pending_priority_paths = desired_pending_paths(priority_paths, uploaded_paths)
-            has_pending_priority = bool(pending_priority_paths)
-            fill_phase_groups: list[list[SegmentTarget]] = []
-            if not has_pending_priority:
+            dm_boost_file_types = [file_type for file_type in ("cameras", "logs", "dcameras", "ecameras") if file_type in file_types]
+            priority_phase = first_pending_phase(
+                [
+                    ("recent_bookmarks", recent_bookmark_targets, file_types),
+                    ("older_bookmarks", older_bookmark_targets, file_types),
+                    ("dm_alerts", dm_alert_targets, dm_boost_file_types),
+                    ("alerts", alert_targets, file_types),
+                ],
+                uploaded_paths,
+            )
+
+            active_phase_name: str | None = None
+            active_phase_targets: list[SegmentTarget] = []
+            desired_paths: list[str] = []
+            pending_paths: list[str] = []
+
+            if priority_phase is not None:
+                active_phase_name, active_phase_targets, _active_phase_file_types, desired_paths, pending_paths = priority_phase
+            else:
                 fill_targets = combine_bookmark_route_fill_segments(
                     bookmark_events=bookmark_events,
                     recent_bookmark_targets=recent_bookmark_targets,
                     older_bookmark_targets=older_bookmark_targets,
                 )
-                fill_phase_groups = [fill_targets.recent_fill_targets, fill_targets.older_fill_targets]
                 print(
                     "Bookmark route fill targets:",
-                    [f"{target.route_id}:{target.segment}" for group in fill_phase_groups for target in group],
+                    [
+                        f"{target.route_id}:{target.segment}"
+                        for target in (fill_targets.recent_fill_targets + fill_targets.older_fill_targets)
+                    ],
                 )
-            desired_paths = priority_paths + generate_candidate_paths_by_priority(fill_phase_groups, file_types)
-            target_paths.update(desired_paths)
-            pending_paths = desired_pending_paths(desired_paths, uploaded_paths)
+                fill_phase = first_pending_phase(
+                    [
+                        ("bookmark_fill_recent", fill_targets.recent_fill_targets, file_types),
+                        ("bookmark_fill_older", fill_targets.older_fill_targets, file_types),
+                    ],
+                    uploaded_paths,
+                )
+                if fill_phase is not None:
+                    active_phase_name, active_phase_targets, _active_phase_file_types, desired_paths, pending_paths = fill_phase
+
+            target_paths = set(desired_paths)
+            has_pending_priority = priority_phase is not None
             has_pending_targets = bool(pending_paths)
-            missing_paths = [path for path in desired_paths if path not in uploaded_paths and path not in queued_paths]
+            missing_paths = [path for path in pending_paths if path not in queued_paths]
             print(
                 "Global segment priority order:",
                 [f"{target.route_id}:{target.segment}" for target in prioritized_segments],
             )
+            if active_phase_name is not None:
+                print(
+                    f"Active phase: {active_phase_name}",
+                    [f"{target.route_id}:{target.segment}" for target in active_phase_targets],
+                )
             print(
                 f"Desired files={len(desired_paths)} uploaded={len(uploaded_paths)} queued={len(queued_paths)} missing={len(missing_paths)}"
             )
@@ -810,6 +940,7 @@ def scan_once(
             if exclusive_bookmark_priority and target_queue_refresh_needed(
                 online_queue,
                 desired_pending_paths=pending_paths,
+                missing_paths=missing_paths,
                 target_paths=target_paths,
             ):
                 cancel_ids = [item["id"] for item in online_queue if item.get("id")]

--- a/tools/comma_watch.py
+++ b/tools/comma_watch.py
@@ -51,6 +51,16 @@ PHASE_REASON_LABELS = {
     "bookmark_fill_recent": "bookmark fill",
     "bookmark_fill_older": "bookmark fill",
 }
+LOW_QUALITY_FILE_KINDS = {"qlog", "qcamera"}
+PHASE_PRIORITY_BASES = {
+    "recent_bookmarks": 0,
+    "older_bookmarks": 12,
+    "dm_alerts": 24,
+    "alerts": 36,
+    "bookmark_fill_recent": 60,
+    "bookmark_fill_older": 72,
+}
+MAX_WATCHER_PRIORITY = 98
 FILE_KIND_BY_TYPE = {
     "cameras": ("fcamera",),
     "logs": ("rlog",),
@@ -802,25 +812,39 @@ def desired_pending_paths(desired_paths: Iterable[str], uploaded_paths: set[str]
 
 
 def target_queue_refresh_needed(
-    online_queue: list[dict[str, Any]],
+    queue_entries: list[QueueEntry],
     *,
-    desired_pending_paths: list[str],
-    missing_paths: list[str],
-    target_paths: set[str],
+    desired_priorities: dict[str, int],
 ) -> bool:
-    if not desired_pending_paths:
+    if not desired_priorities:
         return False
-    if not missing_paths:
-        return False
-    ordered_paths = ordered_online_queue_paths(online_queue)
-    expected_queue_tail = athena_enqueue_order(desired_pending_paths)
-    if len(ordered_paths) < len(expected_queue_tail):
-        return True
-    return ordered_paths[-len(expected_queue_tail) :] != expected_queue_tail
+    for entry in queue_entries:
+        desired_priority = desired_priorities.get(entry.path)
+        if desired_priority is None:
+            continue
+        if entry.priority != desired_priority:
+            return True
+    return False
 
 
 def should_clear_queue_while_waiting(*, prioritized_segments: list[SegmentTarget], has_pending_priority: bool) -> bool:
     return False
+
+
+def watcher_priority_for_index(phase_name: str | None, index: int) -> int:
+    base = PHASE_PRIORITY_BASES.get(phase_name or "", 80)
+    return min(base + index, MAX_WATCHER_PRIORITY)
+
+
+def desired_path_priorities(phase_name: str | None, paths: Iterable[str]) -> dict[str, int]:
+    return {
+        path: watcher_priority_for_index(phase_name, index)
+        for index, path in enumerate(paths)
+    }
+
+
+def is_preserved_queue_entry(entry: QueueEntry) -> bool:
+    return entry.file_kind in LOW_QUALITY_FILE_KINDS
 
 
 def generate_candidate_paths(route: Route, segments: Iterable[int], file_types: Iterable[str]) -> list[str]:
@@ -1218,8 +1242,8 @@ def annotate_queue_entries(
     return annotated
 
 
-def request_uploads(api: CommaApi, dongle_id: str, paths: list[str]) -> dict[str, Any]:
-    ordered_paths = athena_enqueue_order(paths)
+def request_uploads(api: CommaApi, dongle_id: str, paths: list[str], *, priorities: dict[str, int]) -> dict[str, Any]:
+    ordered_paths = list(paths)
     upload_metadata = api.request_upload_urls(dongle_id, ordered_paths)
     files = [
         UploadFile(file_path=path, url=metadata["url"], headers=metadata["headers"])
@@ -1231,7 +1255,7 @@ def request_uploads(api: CommaApi, dongle_id: str, paths: list[str]) -> dict[str
                 "allow_cellular": False,
                 "fn": file.file_path,
                 "headers": file.headers,
-                "priority": 1,
+                "priority": priorities[file.file_path],
                 "url": file.url,
             }
             for file in files
@@ -1479,26 +1503,36 @@ def scan_once(
                     "name": active_phase_name,
                     "targets": [f"{target.route_id}:{target.segment}" for target in active_phase_targets],
                 }
+            pending_priorities = desired_path_priorities(active_phase_name, pending_paths)
             print(
                 f"Desired files={len(desired_paths)} uploaded={len(uploaded_paths)} queued={len(queued_paths)} missing={len(missing_paths)}"
             )
             refreshed_queue = False
             if exclusive_bookmark_priority and target_queue_refresh_needed(
-                online_queue,
-                desired_pending_paths=pending_paths,
-                missing_paths=missing_paths,
-                target_paths=target_paths,
+                queue_entries,
+                desired_priorities=pending_priorities,
             ):
-                cancel_ids = [item["id"] for item in online_queue if item.get("id")]
+                cancel_ids = [
+                    entry.upload_id
+                    for entry in queue_entries
+                    if entry.upload_id
+                    and entry.path in pending_priorities
+                    and entry.priority != pending_priorities[entry.path]
+                ]
                 if cancel_ids:
                     response = api.cancel_uploads(device.dongle_id, cancel_ids)
-                    print(f"Canceled {len(cancel_ids)} queue item(s) to rebuild priority order:")
+                    print(f"Canceled {len(cancel_ids)} queued target item(s) to refresh priorities:")
                     print(json.dumps(response, indent=2))
                     queue_cleared = True
-                online_queue = []
+                online_queue = api.athena_call(device.dongle_id, "listUploadQueue", {}).get("result", [])
+                queue_entries = summarize_online_queue(online_queue)
+                queue_items_by_segment = {}
+                for entry in queue_entries:
+                    queue_items_by_segment.setdefault((entry.route_id, entry.segment), []).append(entry)
                 offline_queue = api.get_athena_offline_queue(device.dongle_id)
                 queued_paths = normalize_queue_paths(online_queue, offline_queue)
                 missing_paths = [path for path in desired_paths if path not in uploaded_paths and path not in queued_paths]
+                pending_priorities = desired_path_priorities(active_phase_name, missing_paths)
                 refreshed_queue = True
 
             if not missing_paths:
@@ -1507,7 +1541,7 @@ def scan_once(
                 else:
                     print("Priority segment files are already uploaded or queued.")
             else:
-                response = request_uploads(api, device.dongle_id, missing_paths)
+                response = request_uploads(api, device.dongle_id, missing_paths, priorities=pending_priorities)
                 print("Queued upload request:")
                 print(json.dumps(response, indent=2))
                 queued_paths.update(missing_paths)
@@ -1547,21 +1581,16 @@ def scan_once(
 
         if exclusive_bookmark_priority:
             if prioritized_segments and has_pending_targets:
-                cancel_ids = [
-                    item["id"]
-                    for item in online_queue
-                    if item.get("id") and normalize_online_queue_item_path(item) not in target_paths
-                ]
-                if cancel_ids:
-                    response = api.cancel_uploads(device.dongle_id, cancel_ids)
-                    print(f"Canceled {len(cancel_ids)} non-priority queue item(s):")
-                    print(json.dumps(response, indent=2))
-                    queue_cleared = True
+                pass
             elif should_clear_queue_while_waiting(
                 prioritized_segments=prioritized_segments,
                 has_pending_priority=has_pending_targets,
             ):
-                cancel_ids = [item["id"] for item in online_queue if item.get("id")]
+                cancel_ids = [
+                    entry.upload_id
+                    for entry in queue_entries
+                    if entry.upload_id and not is_preserved_queue_entry(entry)
+                ]
                 if cancel_ids:
                     response = api.cancel_uploads(device.dongle_id, cancel_ids)
                     print(f"Canceled {len(cancel_ids)} queue item(s) while waiting for priority segments:")

--- a/tools/comma_watch.py
+++ b/tools/comma_watch.py
@@ -23,12 +23,15 @@ DEFAULT_FILE_TYPES = ("cameras", "logs", "ecameras", "dcameras")
 ONLINE_DEVICE_WINDOW_SECONDS = 120
 RECENT_BOOKMARK_COUNT = 5
 ALERT_LOOKBACK_SEGMENTS = 2
+DEFAULT_STATE_PATH = "/tmp/comma-watch-state.json"
 FILE_TYPE_NAMES = {
     "cameras": ("fcamera.hevc",),
     "dcameras": ("dcamera.hevc",),
     "ecameras": ("ecamera.hevc",),
     "logs": ("rlog.bz2", "rlog.zst"),
 }
+DISPLAY_FILE_ORDER = ("fcamera", "rlog", "ecamera", "dcamera")
+DM_DISPLAY_FILE_ORDER = ("fcamera", "rlog", "dcamera", "ecamera")
 BOOKMARK_EVENT_TYPES = {"user_flag", "user_bookmark", "bookmark"}
 USER_PROMPT_ALERT_STATUSES = {1, "1", "userPrompt", "user_prompt"}
 DM_ALERT_HINTS = (
@@ -40,6 +43,20 @@ DM_ALERT_HINTS = (
     "predriverunresponsive",
     "promptdriver",
 )
+PHASE_REASON_LABELS = {
+    "recent_bookmarks": "recent bookmark",
+    "older_bookmarks": "older bookmark",
+    "dm_alerts": "DM alert",
+    "alerts": "alert",
+    "bookmark_fill_recent": "bookmark fill",
+    "bookmark_fill_older": "bookmark fill",
+}
+FILE_KIND_BY_TYPE = {
+    "cameras": ("fcamera",),
+    "logs": ("rlog",),
+    "ecameras": ("ecamera",),
+    "dcameras": ("dcamera",),
+}
 
 
 @dataclass(frozen=True)
@@ -100,6 +117,20 @@ class PriorityEvents:
 class RouteBookmarkFill:
     recent_fill_targets: list[SegmentTarget]
     older_fill_targets: list[SegmentTarget]
+
+
+@dataclass(frozen=True)
+class QueueEntry:
+    path: str
+    route_id: str
+    segment: int
+    filename: str
+    file_kind: str | None
+    current: bool
+    progress: float
+    retry_count: int
+    priority: int | None
+    upload_id: str | None
 
 
 class CommaApi:
@@ -231,6 +262,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Keep the upload queue clear until bookmarks/alerts exist, then keep only those uploads queued.",
     )
+    parser.add_argument(
+        "--state-path",
+        default=os.environ.get("COMMA_WATCH_STATE_PATH", DEFAULT_STATE_PATH),
+        help="Where to write the live watcher JSON state snapshot.",
+    )
     return parser.parse_args()
 
 
@@ -254,6 +290,42 @@ def parse_route_start_utc(start_time: str | None) -> datetime | None:
 
 def route_id_from_fullname(fullname: str) -> str:
     return fullname.split("|", 1)[1]
+
+
+def parse_segment_path(raw_path: str) -> tuple[str, int, str] | None:
+    path = Path(raw_path)
+    segment_dir = path.parent.name
+    if not segment_dir or "--" not in segment_dir:
+        return None
+    route_id, segment_text = segment_dir.rsplit("--", 1)
+    try:
+        segment = int(segment_text)
+    except ValueError:
+        return None
+    return route_id, segment, path.name
+
+
+def file_kind_for_filename(filename: str) -> str | None:
+    if filename == "fcamera.hevc":
+        return "fcamera"
+    if filename == "dcamera.hevc":
+        return "dcamera"
+    if filename == "ecamera.hevc":
+        return "ecamera"
+    if filename in {"rlog.zst", "rlog.bz2"}:
+        return "rlog"
+    if filename.startswith("qlog"):
+        return "qlog"
+    if filename.startswith("qcamera"):
+        return "qcamera"
+    return None
+
+
+def write_state_snapshot(state_path: Path, payload: dict[str, Any]) -> None:
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = state_path.with_suffix(f"{state_path.suffix}.tmp")
+    temp_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temp_path.replace(state_path)
 
 
 def find_device(devices: Iterable[dict[str, Any]], alias: str) -> Device:
@@ -631,6 +703,28 @@ def normalize_uploaded_paths(filelist: dict[str, list[str]]) -> set[str]:
     return uploaded
 
 
+def build_route_file_inventory(filelist: dict[str, list[str]]) -> dict[tuple[str, int], dict[str, bool]]:
+    inventory: dict[tuple[str, int], dict[str, bool]] = {}
+    for urls in filelist.values():
+        for url in urls:
+            parts = url.split("?")[0].split("/")
+            if len(parts) < 3:
+                continue
+            route_id = parts[-3]
+            segment_text = parts[-2]
+            filename = parts[-1]
+            try:
+                segment = int(segment_text)
+            except ValueError:
+                continue
+            kind = file_kind_for_filename(filename)
+            if kind is None:
+                continue
+            key = (route_id, segment)
+            inventory.setdefault(key, empty_segment_files())[kind] = True
+    return inventory
+
+
 def normalize_queue_paths(online_queue: list[dict[str, Any]], offline_queue: list[dict[str, Any]]) -> set[str]:
     queued: set[str] = set()
 
@@ -674,6 +768,33 @@ def ordered_online_queue_paths(online_queue: list[dict[str, Any]]) -> list[str]:
         if normalized is not None:
             ordered_paths.append(normalized)
     return ordered_paths
+
+
+def summarize_online_queue(online_queue: list[dict[str, Any]]) -> list[QueueEntry]:
+    entries: list[QueueEntry] = []
+    for item in online_queue:
+        normalized = normalize_online_queue_item_path(item)
+        if normalized is None:
+            continue
+        parsed = parse_segment_path(normalized)
+        if parsed is None:
+            continue
+        route_id, segment, filename = parsed
+        entries.append(
+            QueueEntry(
+                path=normalized,
+                route_id=route_id,
+                segment=segment,
+                filename=filename,
+                file_kind=file_kind_for_filename(filename),
+                current=bool(item.get("current")),
+                progress=float(item.get("progress") or 0.0),
+                retry_count=int(item.get("retry_count") or 0),
+                priority=item.get("priority"),
+                upload_id=item.get("id"),
+            )
+        )
+    return entries
 
 
 def desired_pending_paths(desired_paths: Iterable[str], uploaded_paths: set[str]) -> list[str]:
@@ -753,6 +874,350 @@ def athena_enqueue_order(paths: Iterable[str]) -> list[str]:
     return list(reversed(list(paths)))
 
 
+def file_kinds_for_file_types(file_types: Iterable[str], *, dm_boost: bool = False) -> list[str]:
+    order = DM_DISPLAY_FILE_ORDER if dm_boost else DISPLAY_FILE_ORDER
+    selected = {
+        kind
+        for file_type in file_types
+        for kind in FILE_KIND_BY_TYPE.get(file_type, ())
+    }
+    return [kind for kind in order if kind in selected]
+
+
+def phase_reason_label(phase_name: str | None) -> str | None:
+    if phase_name is None:
+        return None
+    return PHASE_REASON_LABELS.get(phase_name, phase_name.replace("_", " "))
+
+
+def empty_segment_files() -> dict[str, bool]:
+    return {name: False for name in (*DISPLAY_FILE_ORDER, "qcamera", "qlog")}
+
+
+def phase_segment_lookup(phase_specs: Iterable[tuple[str, list[SegmentTarget]]]) -> dict[tuple[str, int], dict[str, Any]]:
+    lookup: dict[tuple[str, int], dict[str, Any]] = {}
+    for phase_name, targets in phase_specs:
+        for index, target in enumerate(targets, start=1):
+            key = (target.route_id, target.segment)
+            lookup.setdefault(
+                key,
+                {
+                    "phase": phase_name,
+                    "rank": index,
+                },
+            )
+    return lookup
+
+
+def route_segment_rows(
+    *,
+    route: Route,
+    route_inventory: dict[tuple[str, int], dict[str, bool]],
+    queue_items_by_segment: dict[tuple[str, int], list[QueueEntry]],
+    segment_phase_lookup: dict[tuple[str, int], dict[str, Any]],
+    active_phase_targets: list[SegmentTarget],
+    bookmark_segments: set[int],
+    dm_alert_segments: set[int],
+    alert_segments: set[int],
+) -> list[dict[str, Any]]:
+    active_phase_keys = {(target.route_id, target.segment): index for index, target in enumerate(active_phase_targets, start=1)}
+    rows: list[dict[str, Any]] = []
+    for segment in range(route.maxqlog + 1):
+        key = (route.route_id, segment)
+        files = dict(route_inventory.get(key, empty_segment_files()))
+        queue_items = queue_items_by_segment.get(key, [])
+        queued_file_kinds = [item.file_kind for item in queue_items if item.file_kind]
+        active_file_kinds = [item.file_kind for item in queue_items if item.current and item.file_kind]
+        phase_info = segment_phase_lookup.get(key)
+        rows.append(
+            {
+                "segment": segment,
+                "files": files,
+                "bookmark": segment in bookmark_segments,
+                "dm_alert": segment in dm_alert_segments,
+                "alert": segment in alert_segments,
+                "phase": phase_info["phase"] if phase_info else None,
+                "phase_rank": phase_info["rank"] if phase_info else None,
+                "active_phase_rank": active_phase_keys.get(key),
+                "queued_file_kinds": queued_file_kinds,
+                "active_file_kinds": active_file_kinds,
+                "queued_count": len(queue_items),
+                "active_count": sum(1 for item in queue_items if item.current),
+            }
+        )
+    return rows
+
+
+def build_watch_state(
+    *,
+    now_local: datetime,
+    window_start: datetime,
+    devices_state: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "generated_at": now_local.isoformat(),
+        "window_start": window_start.isoformat(),
+        "devices": devices_state,
+    }
+
+
+def segment_status_for_window(
+    *,
+    route_id: str,
+    segment: int,
+    required_file_order: list[str],
+    route_inventory: dict[tuple[str, int], dict[str, bool]],
+    queue_items_by_segment: dict[tuple[str, int], list[QueueEntry]],
+) -> dict[str, Any]:
+    files = route_inventory.get((route_id, segment), empty_segment_files())
+    queue_items = queue_items_by_segment.get((route_id, segment), [])
+
+    uploaded = [kind for kind in required_file_order if files.get(kind)]
+    active = []
+    queued = []
+    for kind in required_file_order:
+        if kind in uploaded:
+            continue
+        matching = [item for item in queue_items if item.file_kind == kind]
+        if any(item.current for item in matching):
+            active.append(kind)
+        elif matching:
+            queued.append(kind)
+    missing = [kind for kind in required_file_order if kind not in uploaded and kind not in active and kind not in queued]
+    return {
+        "segment": segment,
+        "uploaded_file_kinds": uploaded,
+        "queued_file_kinds": queued,
+        "active_file_kinds": active,
+        "missing_file_kinds": missing,
+        "is_complete": not active and not queued and not missing,
+    }
+
+
+def summarize_incident_completion(segment_statuses: list[dict[str, Any]]) -> dict[str, int]:
+    uploaded = sum(len(status["uploaded_file_kinds"]) for status in segment_statuses)
+    queued = sum(len(status["queued_file_kinds"]) for status in segment_statuses)
+    active = sum(len(status["active_file_kinds"]) for status in segment_statuses)
+    missing = sum(len(status["missing_file_kinds"]) for status in segment_statuses)
+    return {
+        "uploaded": uploaded,
+        "queued": queued,
+        "active": active,
+        "missing": missing,
+        "total": uploaded + queued + active + missing,
+    }
+
+
+def incident_ready_state(segment_statuses: list[dict[str, Any]]) -> str:
+    if segment_statuses and all(status["is_complete"] for status in segment_statuses):
+        return "complete"
+    if any(status["active_file_kinds"] for status in segment_statuses):
+        return "in_progress"
+    if any(status["queued_file_kinds"] for status in segment_statuses):
+        return "queued"
+    return "waiting"
+
+
+def first_incomplete_segment(segment_statuses: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for status in segment_statuses:
+        if status["is_complete"]:
+            continue
+        return {
+            "segment": status["segment"],
+            "missing_file_kinds": list(status["missing_file_kinds"]),
+            "queued_file_kinds": list(status["queued_file_kinds"]),
+            "active_file_kinds": list(status["active_file_kinds"]),
+        }
+    return None
+
+
+def currently_uploading_files(segment_statuses: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    files: list[dict[str, Any]] = []
+    for status in segment_statuses:
+        for kind in status["active_file_kinds"]:
+            files.append({"segment": status["segment"], "file_kind": kind})
+    return files
+
+
+def build_incident_windows(
+    *,
+    routes_by_id: dict[str, Route],
+    bookmark_events: list[SegmentEvent],
+    dm_alert_events: list[SegmentEvent],
+    alert_events: list[SegmentEvent],
+    recent_bookmark_targets: list[SegmentTarget],
+    older_bookmark_targets: list[SegmentTarget],
+    active_phase_name: str | None,
+    active_phase_targets: list[SegmentTarget],
+    recent_fill_targets: list[SegmentTarget],
+    older_fill_targets: list[SegmentTarget],
+    previous_segments: int,
+    next_segments: int,
+    alert_lookback_segments: int,
+    file_types: list[str],
+    route_inventories: dict[str, dict[tuple[str, int], dict[str, bool]]],
+    queue_items_by_segment: dict[tuple[str, int], list[QueueEntry]],
+) -> list[dict[str, Any]]:
+    active_phase_keys = {(target.route_id, target.segment) for target in active_phase_targets}
+    recent_fill_routes = {target.route_id for target in recent_fill_targets}
+    older_fill_routes = {target.route_id for target in older_fill_targets}
+    windows: list[dict[str, Any]] = []
+
+    bookmark_events_sorted = sorted(bookmark_events, key=lambda event: event.event_time)
+    recent_bookmark_events = list(reversed(bookmark_events_sorted[-RECENT_BOOKMARK_COUNT:]))
+    older_bookmark_events = bookmark_events_sorted[:-RECENT_BOOKMARK_COUNT]
+    dm_alert_events_sorted = sorted(dm_alert_events, key=lambda event: event.event_time)
+    alert_events_sorted = sorted(alert_events, key=lambda event: event.event_time)
+
+    def append_window(event: SegmentEvent, *, category: str, base_phase: str) -> None:
+        route = routes_by_id[event.route_id]
+        if category == "bookmark":
+            segment_order = prioritize_segments(
+                [event.segment],
+                previous_segments=previous_segments,
+                next_segments=next_segments,
+                max_segment=event.max_segment,
+            )
+            required_order = file_kinds_for_file_types(file_types)
+        elif category == "dm_alert":
+            segment_order = alert_segments_with_lookback(
+                event.segment,
+                previous_segments=alert_lookback_segments,
+                max_segment=event.max_segment,
+            )
+            required_order = file_kinds_for_file_types(file_types, dm_boost=True)
+        else:
+            segment_order = alert_segments_with_lookback(
+                event.segment,
+                previous_segments=alert_lookback_segments,
+                max_segment=event.max_segment,
+            )
+            required_order = file_kinds_for_file_types(file_types)
+
+        segment_statuses = [
+            segment_status_for_window(
+                route_id=event.route_id,
+                segment=segment,
+                required_file_order=required_order,
+                route_inventory=route_inventories.get(event.route_id, {}),
+                queue_items_by_segment=queue_items_by_segment,
+            )
+            for segment in segment_order
+        ]
+        completion = summarize_incident_completion(segment_statuses)
+        ready_state = incident_ready_state(segment_statuses)
+
+        phase_membership = base_phase
+        is_active_phase_window = any((event.route_id, segment) in active_phase_keys for segment in segment_order)
+        if category == "bookmark" and active_phase_name == "bookmark_fill_recent" and event.route_id in recent_fill_routes:
+            phase_membership = "bookmark_fill_recent"
+            is_active_phase_window = True
+        elif category == "bookmark" and active_phase_name == "bookmark_fill_older" and event.route_id in older_fill_routes:
+            phase_membership = "bookmark_fill_older"
+            is_active_phase_window = True
+        elif active_phase_name == base_phase and is_active_phase_window:
+            phase_membership = base_phase
+
+        windows.append(
+            {
+                "id": f"{category}:{event.route_id}:{event.segment}",
+                "category": category,
+                "route_id": event.route_id,
+                "event_time": event.event_time.isoformat(),
+                "anchor_segment": event.segment,
+                "segment_order": segment_order,
+                "phase_membership": phase_membership,
+                "is_active_phase_window": is_active_phase_window,
+                "route_start_time": route.start_time,
+                "segment_statuses": segment_statuses,
+                "required_file_order": required_order,
+                "completion": completion,
+                "first_incomplete_segment": first_incomplete_segment(segment_statuses),
+                "currently_uploading_files": currently_uploading_files(segment_statuses),
+                "ready_state": ready_state,
+            }
+        )
+
+    for event in recent_bookmark_events:
+        append_window(event, category="bookmark", base_phase="recent_bookmarks")
+    for event in older_bookmark_events:
+        append_window(event, category="bookmark", base_phase="older_bookmarks")
+    for event in dm_alert_events_sorted:
+        append_window(event, category="dm_alert", base_phase="dm_alerts")
+    for event in alert_events_sorted:
+        append_window(event, category="alert", base_phase="alerts")
+
+    windows.sort(
+        key=lambda window: (
+            0 if window["is_active_phase_window"] else 1,
+            {
+                "recent_bookmarks": 0,
+                "older_bookmarks": 1,
+                "dm_alerts": 2,
+                "alerts": 3,
+                "bookmark_fill_recent": 4,
+                "bookmark_fill_older": 5,
+            }.get(window["phase_membership"], 6),
+            window["event_time"],
+        )
+    )
+    return windows
+
+
+def annotate_queue_entries(
+    queue_entries: list[QueueEntry],
+    *,
+    incident_windows: list[dict[str, Any]],
+    active_phase_name: str | None,
+    active_phase_targets: list[SegmentTarget],
+) -> list[dict[str, Any]]:
+    active_phase_keys = {(target.route_id, target.segment) for target in active_phase_targets}
+    annotated: list[dict[str, Any]] = []
+    for entry in queue_entries:
+        incident_context: dict[str, Any] | None = None
+        for window in incident_windows:
+            if window["route_id"] != entry.route_id or entry.segment not in window["segment_order"]:
+                continue
+            segment_rank = window["segment_order"].index(entry.segment) + 1
+            file_rank = window["required_file_order"].index(entry.file_kind) + 1 if entry.file_kind in window["required_file_order"] else None
+            incident_context = {
+                "incident_window_id": window["id"],
+                "reason_label": phase_reason_label(window["phase_membership"]),
+                "segment_rank_within_window": segment_rank,
+                "file_rank_within_segment": file_rank,
+            }
+            break
+        if incident_context is None and (entry.route_id, entry.segment) in active_phase_keys and active_phase_name in {
+            "bookmark_fill_recent",
+            "bookmark_fill_older",
+        }:
+            incident_context = {
+                "incident_window_id": None,
+                "reason_label": phase_reason_label(active_phase_name),
+                "segment_rank_within_window": None,
+                "file_rank_within_segment": None,
+            }
+        annotated.append(
+            {
+                "path": entry.path,
+                "route_id": entry.route_id,
+                "segment": entry.segment,
+                "filename": entry.filename,
+                "file_kind": entry.file_kind,
+                "current": entry.current,
+                "progress": entry.progress,
+                "retry_count": entry.retry_count,
+                "priority": entry.priority,
+                "upload_id": entry.upload_id,
+                "incident_window_id": incident_context["incident_window_id"] if incident_context else None,
+                "reason_label": incident_context["reason_label"] if incident_context else None,
+                "segment_rank_within_window": incident_context["segment_rank_within_window"] if incident_context else None,
+                "file_rank_within_segment": incident_context["file_rank_within_segment"] if incident_context else None,
+            }
+        )
+    return annotated
+
+
 def request_uploads(api: CommaApi, dongle_id: str, paths: list[str]) -> dict[str, Any]:
     ordered_paths = athena_enqueue_order(paths)
     upload_metadata = api.request_upload_urls(dongle_id, ordered_paths)
@@ -785,6 +1250,7 @@ def scan_once(
     next_segments: int,
     file_types: list[str],
     exclusive_bookmark_priority: bool,
+    state_path: Path,
 ) -> ScanOutcome:
     targets_found = False
     uploads_queued = False
@@ -793,11 +1259,13 @@ def scan_once(
     devices = select_devices(api.get_devices(), device_alias or None)
     now_local = datetime.now(tz)
     window_start = now_local - timedelta(hours=lookback_hours)
+    watcher_state = build_watch_state(now_local=now_local, window_start=window_start, devices_state=[])
     print(
         f"[{now_local.isoformat()}] Watching {len(devices)} device(s) in the last {lookback_hours} hour(s) "
         f"since {window_start.isoformat()}"
     )
     if not devices:
+        write_state_snapshot(state_path, watcher_state)
         return ScanOutcome(targets_found=False, uploads_queued=False, all_target_files_satisfied=False, queue_cleared=False)
 
     any_routes_found = False
@@ -805,18 +1273,63 @@ def scan_once(
         print(f"Device {device.alias or device.dongle_id} ({device.dongle_id})")
         routes = list_routes_in_lookback_window(api, device.dongle_id, window_start=window_start, tz=tz)
         print(f"Found {len(routes)} route(s) in lookback window")
+        device_state: dict[str, Any] = {
+            "alias": device.alias,
+            "dongle_id": device.dongle_id,
+            "routes": [],
+            "incident_windows": [],
+            "queue": {
+                "length": 0,
+                "active_length": 0,
+                "items": [],
+            },
+            "active_phase": None,
+        }
+        watcher_state["devices"].append(device_state)
         if not routes:
             continue
         any_routes_found = True
 
         online_queue = api.athena_call(device.dongle_id, "listUploadQueue", {}).get("result", [])
         offline_queue = api.get_athena_offline_queue(device.dongle_id)
+        queue_entries = summarize_online_queue(online_queue)
+        queue_items_by_segment: dict[tuple[str, int], list[QueueEntry]] = {}
+        for entry in queue_entries:
+            queue_items_by_segment.setdefault((entry.route_id, entry.segment), []).append(entry)
+        device_state["queue"] = {
+            "length": len(queue_entries),
+            "active_length": sum(1 for entry in queue_entries if entry.current),
+            "items": [
+                {
+                    "path": entry.path,
+                    "route_id": entry.route_id,
+                    "segment": entry.segment,
+                    "filename": entry.filename,
+                    "file_kind": entry.file_kind,
+                    "current": entry.current,
+                    "progress": entry.progress,
+                    "retry_count": entry.retry_count,
+                    "priority": entry.priority,
+                    "upload_id": entry.upload_id,
+                }
+                for entry in queue_entries
+            ],
+        }
         queued_paths = normalize_queue_paths(online_queue, offline_queue)
         target_paths: set[str] = set()
         uploaded_paths: set[str] = set()
         bookmark_events: list[SegmentEvent] = []
         dm_alert_events: list[SegmentEvent] = []
         alert_events: list[SegmentEvent] = []
+        routes_by_id: dict[str, Route] = {}
+        route_states_by_id: dict[str, dict[str, Any]] = {}
+        route_inventories: dict[str, dict[tuple[str, int], dict[str, bool]]] = {}
+        route_bookmark_segments: dict[str, set[int]] = {}
+        route_dm_alert_segments: dict[str, set[int]] = {}
+        route_alert_segments: dict[str, set[int]] = {}
+        active_phase_name: str | None = None
+        recent_fill_targets: list[SegmentTarget] = []
+        older_fill_targets: list[SegmentTarget] = []
 
         for route in routes:
             route_detail = api.get_route(route.fullname)
@@ -830,6 +1343,7 @@ def scan_once(
                 url=route_detail.get("url", route.url),
             )
             start_local = parse_route_start_local(hydrated_route.start_time, tz)
+            routes_by_id[hydrated_route.route_id] = hydrated_route
             route_files = api.get_route_files(hydrated_route.fullname)
             qlog_count = len(route_files.get("qlogs", []))
             parsed_upper_bound = parsed_segment_upper_bound(hydrated_route)
@@ -840,10 +1354,14 @@ def scan_once(
             if parsed_upper_bound < hydrated_route.maxqlog:
                 print(f"Waiting for parsed qlogs: scanning segments 0..{parsed_upper_bound} so far")
             uploaded_paths.update(normalize_uploaded_paths(route_files))
+            route_inventories[hydrated_route.route_id] = build_route_file_inventory(route_files)
             priority_events = collect_priority_events(api, hydrated_route)
             bookmark_segments = sorted({event.segment for event in priority_events.bookmark_events})
             dm_alert_segments = sorted({event.segment for event in priority_events.dm_alert_events})
             alert_segments = sorted({event.segment for event in priority_events.alert_events})
+            route_bookmark_segments[hydrated_route.route_id] = set(bookmark_segments)
+            route_dm_alert_segments[hydrated_route.route_id] = set(dm_alert_segments)
+            route_alert_segments[hydrated_route.route_id] = set(alert_segments)
             print(f"Bookmarked segments: {bookmark_segments}")
             print(f"DM alert segments: {dm_alert_segments}")
             print(f"Alert segments: {alert_segments}")
@@ -852,6 +1370,21 @@ def scan_once(
             bookmark_events.extend(priority_events.bookmark_events)
             dm_alert_events.extend(priority_events.dm_alert_events)
             alert_events.extend(priority_events.alert_events)
+            route_state = {
+                "fullname": hydrated_route.fullname,
+                "route_id": hydrated_route.route_id,
+                "start_time": hydrated_route.start_time,
+                "end_time": hydrated_route.end_time,
+                "maxqlog": hydrated_route.maxqlog,
+                "procqlog": hydrated_route.procqlog,
+                "qlogs": qlog_count,
+                "bookmark_segments": bookmark_segments,
+                "dm_alert_segments": dm_alert_segments,
+                "alert_segments": alert_segments,
+                "segments": [],
+            }
+            route_states_by_id[hydrated_route.route_id] = route_state
+            device_state["routes"].append(route_state)
 
         prioritized_segment_groups = combine_priority_segments(
             bookmark_events=bookmark_events,
@@ -878,8 +1411,16 @@ def scan_once(
             "Alert targets:",
             [f"{target.route_id}:{target.segment}" for target in alert_targets],
         )
+        segment_lookup: dict[tuple[str, int], dict[str, Any]] = {}
+        active_phase_targets: list[SegmentTarget] = []
         if prioritized_segments:
             dm_boost_file_types = [file_type for file_type in ("cameras", "logs", "dcameras", "ecameras") if file_type in file_types]
+            named_phase_targets = [
+                ("recent_bookmarks", recent_bookmark_targets),
+                ("older_bookmarks", older_bookmark_targets),
+                ("dm_alerts", dm_alert_targets),
+                ("alerts", alert_targets),
+            ]
             priority_phase = first_pending_phase(
                 [
                     ("recent_bookmarks", recent_bookmark_targets, file_types),
@@ -890,7 +1431,6 @@ def scan_once(
                 uploaded_paths,
             )
 
-            active_phase_name: str | None = None
             active_phase_targets: list[SegmentTarget] = []
             desired_paths: list[str] = []
             pending_paths: list[str] = []
@@ -910,6 +1450,8 @@ def scan_once(
                         for target in (fill_targets.recent_fill_targets + fill_targets.older_fill_targets)
                     ],
                 )
+                recent_fill_targets = fill_targets.recent_fill_targets
+                older_fill_targets = fill_targets.older_fill_targets
                 fill_phase = first_pending_phase(
                     [
                         ("bookmark_fill_recent", fill_targets.recent_fill_targets, file_types),
@@ -933,6 +1475,10 @@ def scan_once(
                     f"Active phase: {active_phase_name}",
                     [f"{target.route_id}:{target.segment}" for target in active_phase_targets],
                 )
+                device_state["active_phase"] = {
+                    "name": active_phase_name,
+                    "targets": [f"{target.route_id}:{target.segment}" for target in active_phase_targets],
+                }
             print(
                 f"Desired files={len(desired_paths)} uploaded={len(uploaded_paths)} queued={len(queued_paths)} missing={len(missing_paths)}"
             )
@@ -967,11 +1513,37 @@ def scan_once(
                 queued_paths.update(missing_paths)
                 uploads_queued = True
                 all_target_files_satisfied = False
+
+            segment_lookup = phase_segment_lookup(named_phase_targets)
+            for route in routes:
+                route_state = route_states_by_id[route.route_id]
+                route_state["segments"] = route_segment_rows(
+                    route=routes_by_id[route.route_id],
+                    route_inventory=route_inventories.get(route.route_id, {}),
+                    queue_items_by_segment=queue_items_by_segment,
+                    segment_phase_lookup=segment_lookup,
+                    active_phase_targets=active_phase_targets,
+                    bookmark_segments=route_bookmark_segments.get(route.route_id, set()),
+                    dm_alert_segments=route_dm_alert_segments.get(route.route_id, set()),
+                    alert_segments=route_alert_segments.get(route.route_id, set()),
+                )
         else:
             print("No bookmark or alert targets found in lookback window.")
             all_target_files_satisfied = False
             has_pending_priority = False
             has_pending_targets = False
+            for route in routes:
+                route_state = route_states_by_id[route.route_id]
+                route_state["segments"] = route_segment_rows(
+                    route=routes_by_id[route.route_id],
+                    route_inventory=route_inventories.get(route.route_id, {}),
+                    queue_items_by_segment=queue_items_by_segment,
+                    segment_phase_lookup={},
+                    active_phase_targets=[],
+                    bookmark_segments=route_bookmark_segments.get(route.route_id, set()),
+                    dm_alert_segments=route_dm_alert_segments.get(route.route_id, set()),
+                    alert_segments=route_alert_segments.get(route.route_id, set()),
+                )
 
         if exclusive_bookmark_priority:
             if prioritized_segments and has_pending_targets:
@@ -996,8 +1568,56 @@ def scan_once(
                     print(json.dumps(response, indent=2))
                     queue_cleared = True
 
+        refreshed_online_queue = api.athena_call(device.dongle_id, "listUploadQueue", {}).get("result", [])
+        refreshed_queue_entries = summarize_online_queue(refreshed_online_queue)
+        refreshed_queue_by_segment: dict[tuple[str, int], list[QueueEntry]] = {}
+        for entry in refreshed_queue_entries:
+            refreshed_queue_by_segment.setdefault((entry.route_id, entry.segment), []).append(entry)
+        incident_windows = build_incident_windows(
+            routes_by_id=routes_by_id,
+            bookmark_events=bookmark_events,
+            dm_alert_events=dm_alert_events,
+            alert_events=alert_events,
+            recent_bookmark_targets=recent_bookmark_targets,
+            older_bookmark_targets=older_bookmark_targets,
+            active_phase_name=active_phase_name if prioritized_segments else None,
+            active_phase_targets=active_phase_targets,
+            recent_fill_targets=recent_fill_targets,
+            older_fill_targets=older_fill_targets,
+            previous_segments=previous_segments,
+            next_segments=next_segments,
+            alert_lookback_segments=ALERT_LOOKBACK_SEGMENTS,
+            file_types=file_types,
+            route_inventories=route_inventories,
+            queue_items_by_segment=refreshed_queue_by_segment,
+        )
+        device_state["queue"] = {
+            "length": len(refreshed_queue_entries),
+            "active_length": sum(1 for entry in refreshed_queue_entries if entry.current),
+            "items": annotate_queue_entries(
+                refreshed_queue_entries,
+                incident_windows=incident_windows,
+                active_phase_name=active_phase_name if prioritized_segments else None,
+                active_phase_targets=active_phase_targets,
+            ),
+        }
+        device_state["incident_windows"] = incident_windows
+        for route in routes:
+            route_state = route_states_by_id[route.route_id]
+            route_state["segments"] = route_segment_rows(
+                route=routes_by_id[route.route_id],
+                route_inventory=route_inventories.get(route.route_id, {}),
+                queue_items_by_segment=refreshed_queue_by_segment,
+                segment_phase_lookup=segment_lookup,
+                active_phase_targets=active_phase_targets,
+                bookmark_segments=route_bookmark_segments.get(route.route_id, set()),
+                dm_alert_segments=route_dm_alert_segments.get(route.route_id, set()),
+                alert_segments=route_alert_segments.get(route.route_id, set()),
+            )
+
     if not any_routes_found or not targets_found:
         all_target_files_satisfied = False
+    write_state_snapshot(state_path, watcher_state)
     return ScanOutcome(
         targets_found=targets_found,
         uploads_queued=uploads_queued,
@@ -1014,6 +1634,7 @@ def main() -> int:
 
     tz = ZoneInfo(args.timezone)
     api = CommaApi(args.jwt_token)
+    state_path = Path(args.state_path)
 
     start_time = time.monotonic()
     outcome = ScanOutcome(targets_found=False, uploads_queued=False, all_target_files_satisfied=False, queue_cleared=False)
@@ -1028,6 +1649,7 @@ def main() -> int:
                 next_segments=args.next_segments,
                 file_types=args.file_types,
                 exclusive_bookmark_priority=args.exclusive_bookmark_priority,
+                state_path=state_path,
             )
             if args.exit_when_satisfied and outcome.targets_found and (
                 outcome.uploads_queued or outcome.all_target_files_satisfied

--- a/tools/comma_watch_dashboard.html
+++ b/tools/comma_watch_dashboard.html
@@ -271,6 +271,18 @@
         margin-bottom: 8px;
       }
 
+      .incident-meta {
+        display: grid;
+        gap: 8px;
+        justify-items: end;
+      }
+
+      .chip-block {
+        display: grid;
+        gap: 4px;
+        justify-items: end;
+      }
+
       .incident-route {
         font-weight: 730;
       }
@@ -925,7 +937,8 @@
         .queue-primary,
         .queue-group-head,
         .route-head,
-        .section-head {
+        .section-head,
+        .incident-top {
           flex-direction: column;
           align-items: flex-start;
         }
@@ -933,6 +946,11 @@
         .device-status {
           justify-items: start;
           text-align: left;
+        }
+
+        .incident-meta,
+        .chip-block {
+          justify-items: start;
         }
       }
 
@@ -1088,11 +1106,9 @@
         const card = document.createElement("section");
         card.className = `incident-card ${window.is_active_phase_window ? "active-window" : ""}`;
 
-        const chips = [
-          `<span class="chip ${categoryClass(window.category)}">${categoryLabel(window.category)}</span>`,
-          `<span class="chip phase">${titleCase(window.phase_membership || "none")}</span>`,
-          `<span class="chip neutral">${titleCase(window.ready_state)}</span>`,
-        ];
+        const reasonChip = `<span class="chip phase">${titleCase(window.phase_membership || "none")}</span>`;
+        const typeChip = `<span class="chip ${categoryClass(window.category)}">${categoryLabel(window.category)}</span>`;
+        const stateChip = `<span class="chip neutral">${titleCase(window.ready_state)}</span>`;
 
         const segmentPills = (window.segment_statuses || [])
           .map((status, index) => `<span class="${segmentPillClass(status)}">#${status.segment}</span>`)
@@ -1136,7 +1152,20 @@
               <div class="incident-route">${window.route_id}</div>
               <div class="incident-time">${fmtTime(window.route_start_time)}</div>
             </div>
-            <div class="chip-row">${chips.join("")}</div>
+            <div class="incident-meta">
+              <div class="chip-block">
+                <div class="inline-label">Reason</div>
+                <div class="chip-row">${reasonChip}</div>
+              </div>
+              <div class="chip-block">
+                <div class="inline-label">Incident</div>
+                <div class="chip-row">${typeChip}</div>
+              </div>
+              <div class="chip-block">
+                <div class="inline-label">State</div>
+                <div class="chip-row">${stateChip}</div>
+              </div>
+            </div>
           </div>
           <div class="incident-status">${incidentStatusLine(window)}</div>
           <div class="segment-pill-row">${segmentPills}</div>
@@ -1157,8 +1186,9 @@
         wrapper.className = "incident-explainer";
         wrapper.innerHTML = `
           <div class="incident-explainer-copy">
-            Each segment card shows the exact files needed to make that minute clip-usable. Every row is one file:
-            forward camera, route log, wide camera, and driver camera.
+            Each card is one incident window. The Reason chip tells you why the watcher picked this window, the
+            Incident chip tells you what kind of event it is, and the State chip tells you whether that window is
+            complete or still being assembled. Inside each segment card, every row is one required file.
           </div>
           <div class="file-key">
             <span class="key-chip"><strong>Fwd</strong> forward camera</span>

--- a/tools/comma_watch_dashboard.html
+++ b/tools/comma_watch_dashboard.html
@@ -1,0 +1,1503 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Comma Watch Dashboard</title>
+    <style>
+      :root {
+        --bg: #091017;
+        --panel: rgba(15, 22, 31, 0.92);
+        --panel-2: rgba(21, 30, 42, 0.96);
+        --panel-3: rgba(12, 17, 25, 0.86);
+        --line: rgba(255, 255, 255, 0.08);
+        --line-strong: rgba(255, 255, 255, 0.14);
+        --text: #edf4ff;
+        --muted: #90a4ba;
+        --muted-2: #6d8096;
+        --accent: #5ea2ff;
+        --bookmark: #f0c63c;
+        --bookmark-bg: rgba(240, 198, 60, 0.18);
+        --alert: #f2994a;
+        --alert-bg: rgba(242, 153, 74, 0.18);
+        --dm: #ff8b94;
+        --dm-bg: rgba(255, 139, 148, 0.2);
+        --success: #31bf7a;
+        --success-deep: #1f7f53;
+        --queue: #58a6ff;
+        --active: #ffffff;
+        --shadow: 0 20px 48px rgba(0, 0, 0, 0.28);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font: 14px/1.45 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        color: var(--text);
+        background:
+          radial-gradient(circle at top left, rgba(94, 162, 255, 0.14), transparent 28%),
+          radial-gradient(circle at top right, rgba(242, 153, 74, 0.12), transparent 24%),
+          linear-gradient(180deg, #0b1119 0%, #081018 100%);
+      }
+
+      button,
+      summary {
+        font: inherit;
+      }
+
+      .shell {
+        max-width: 1540px;
+        margin: 0 auto;
+        padding: 18px 20px 28px;
+      }
+
+      .hero {
+        display: flex;
+        justify-content: space-between;
+        gap: 20px;
+        align-items: flex-start;
+        margin-bottom: 16px;
+      }
+
+      .hero h1 {
+        margin: 0;
+        font-size: 32px;
+        line-height: 1.04;
+        letter-spacing: -0.03em;
+      }
+
+      .hero p {
+        margin: 8px 0 0;
+        max-width: 760px;
+        color: var(--muted);
+      }
+
+      .stamp {
+        flex: 0 0 auto;
+        padding: 9px 12px;
+        border-radius: 999px;
+        color: var(--muted);
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.07);
+      }
+
+      .overview {
+        display: grid;
+        grid-template-columns: repeat(6, minmax(0, 1fr));
+        gap: 10px;
+        margin-bottom: 14px;
+      }
+
+      .metric {
+        padding: 12px 14px;
+        border-radius: 16px;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.025), rgba(255, 255, 255, 0.012));
+        border: 1px solid var(--line);
+        box-shadow: var(--shadow);
+      }
+
+      .metric-label {
+        color: var(--muted-2);
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .metric-value {
+        margin-top: 6px;
+        font-size: 26px;
+        font-weight: 750;
+        line-height: 1.1;
+      }
+
+      .layout {
+        display: grid;
+        grid-template-columns: minmax(0, 1.9fr) minmax(320px, 0.92fr);
+        gap: 14px;
+      }
+
+      .stack {
+        display: grid;
+        gap: 14px;
+      }
+
+      .card {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 22px;
+        box-shadow: var(--shadow);
+        backdrop-filter: blur(14px);
+      }
+
+      .device-card {
+        padding: 18px;
+      }
+
+      .device-head {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        align-items: flex-start;
+      }
+
+      .device-name {
+        font-size: 24px;
+        font-weight: 760;
+        letter-spacing: -0.02em;
+      }
+
+      .device-meta {
+        color: var(--muted);
+        font-size: 13px;
+      }
+
+      .device-status {
+        display: grid;
+        gap: 4px;
+        justify-items: end;
+        text-align: right;
+        color: var(--muted);
+        font-size: 13px;
+      }
+
+      .phase-banner {
+        margin-top: 14px;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        align-items: flex-start;
+        padding: 12px 14px;
+        border-radius: 16px;
+        background: linear-gradient(90deg, rgba(94, 162, 255, 0.13), rgba(240, 198, 60, 0.12));
+        border: 1px solid rgba(255, 255, 255, 0.08);
+      }
+
+      .phase-title {
+        font-size: 12px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--muted-2);
+      }
+
+      .phase-name {
+        margin-top: 4px;
+        font-size: 20px;
+        font-weight: 730;
+        letter-spacing: -0.02em;
+      }
+
+      .phase-summary {
+        margin-top: 4px;
+        color: var(--muted);
+      }
+
+      .phase-count {
+        white-space: nowrap;
+        color: var(--muted);
+      }
+
+      .section-head {
+        display: flex;
+        justify-content: space-between;
+        gap: 10px;
+        align-items: baseline;
+        margin: 18px 0 12px;
+      }
+
+      .section-head h2,
+      .queue-card h2 {
+        margin: 0;
+        font-size: 19px;
+        letter-spacing: -0.02em;
+      }
+
+      .section-note {
+        color: var(--muted);
+        font-size: 13px;
+      }
+
+      .key-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin: 0 0 12px;
+      }
+
+      .key-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 10px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      .key-chip strong {
+        color: var(--text);
+        font-size: 11px;
+        letter-spacing: 0.04em;
+      }
+
+      .incident-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .incident-card {
+        padding: 14px;
+        border-radius: 18px;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.015));
+        border: 1px solid var(--line);
+      }
+
+      .incident-card.active-window {
+        border-color: rgba(94, 162, 255, 0.35);
+        box-shadow: 0 0 0 1px rgba(94, 162, 255, 0.12);
+      }
+
+      .incident-top {
+        display: flex;
+        justify-content: space-between;
+        gap: 10px;
+        align-items: flex-start;
+        margin-bottom: 8px;
+      }
+
+      .incident-route {
+        font-weight: 730;
+      }
+
+      .incident-time {
+        margin-top: 2px;
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      .incident-status {
+        margin: 10px 0 12px;
+        color: var(--muted);
+      }
+
+      .chip-row,
+      .segment-pill-row,
+      .file-chip-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        border-radius: 999px;
+        padding: 4px 10px;
+        font-size: 12px;
+        border: 1px solid transparent;
+      }
+
+      .chip.bookmark {
+        color: #f7df88;
+        background: var(--bookmark-bg);
+        border-color: rgba(240, 198, 60, 0.22);
+      }
+
+      .chip.alert {
+        color: #fdc88f;
+        background: var(--alert-bg);
+        border-color: rgba(242, 153, 74, 0.2);
+      }
+
+      .chip.dm-alert {
+        color: #ffb1b7;
+        background: var(--dm-bg);
+        border-color: rgba(255, 139, 148, 0.24);
+      }
+
+      .chip.phase {
+        color: #cae0ff;
+        background: rgba(94, 162, 255, 0.12);
+        border-color: rgba(94, 162, 255, 0.18);
+      }
+
+      .chip.neutral {
+        color: var(--muted);
+        background: rgba(255, 255, 255, 0.04);
+        border-color: rgba(255, 255, 255, 0.08);
+      }
+
+      .segment-pill {
+        min-width: 34px;
+        justify-content: center;
+        color: var(--muted);
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+      }
+
+      .segment-pill.complete {
+        color: #dbffe9;
+        background: rgba(49, 191, 122, 0.18);
+        border-color: rgba(49, 191, 122, 0.24);
+      }
+
+      .segment-pill.active {
+        color: #fff;
+        background: rgba(94, 162, 255, 0.22);
+        border-color: rgba(94, 162, 255, 0.3);
+      }
+
+      .segment-pill.queued {
+        color: #d5e7ff;
+        background: rgba(94, 162, 255, 0.1);
+        border-color: rgba(94, 162, 255, 0.18);
+      }
+
+      .incident-strip {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(44px, 1fr));
+        gap: 6px;
+        margin-top: 10px;
+      }
+
+      .incident-explainer {
+        display: grid;
+        gap: 10px;
+        margin-top: 10px;
+        margin-bottom: 14px;
+        padding: 12px 14px;
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.03);
+        border: 1px solid rgba(255, 255, 255, 0.06);
+      }
+
+      .incident-explainer-copy {
+        color: var(--muted);
+        line-height: 1.5;
+      }
+
+      .file-key,
+      .status-key {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .key-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        min-height: 30px;
+        padding: 6px 10px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        color: #dce9f8;
+        font-size: 12px;
+      }
+
+      .status-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 999px;
+        flex: 0 0 auto;
+      }
+
+      .status-dot.uploaded {
+        background: linear-gradient(90deg, var(--success), var(--success-deep));
+      }
+
+      .status-dot.active {
+        background: linear-gradient(90deg, #ffffff, #91c4ff);
+      }
+
+      .status-dot.queued {
+        background: linear-gradient(90deg, rgba(94, 162, 255, 0.85), rgba(94, 162, 255, 0.55));
+      }
+
+      .status-dot.missing {
+        background: rgba(255, 255, 255, 0.18);
+      }
+
+      .incident-segment {
+        padding: 7px 8px 8px;
+        border-radius: 12px;
+        background: var(--panel-3);
+        border: 1px solid rgba(255, 255, 255, 0.05);
+      }
+
+      .incident-segment.complete {
+        border-color: rgba(49, 191, 122, 0.24);
+        background: rgba(49, 191, 122, 0.09);
+      }
+
+      .incident-segment.active {
+        border-color: rgba(94, 162, 255, 0.28);
+        background: rgba(94, 162, 255, 0.12);
+      }
+
+      .incident-segment-header {
+        display: flex;
+        justify-content: space-between;
+        gap: 6px;
+        align-items: center;
+        margin-bottom: 6px;
+        font-size: 12px;
+      }
+
+      .incident-segment-rank {
+        color: var(--muted-2);
+        font-size: 11px;
+      }
+
+      .mini-files {
+        display: grid;
+        gap: 4px;
+      }
+
+      .mini-file-row {
+        display: grid;
+        grid-template-columns: 36px minmax(0, 1fr);
+        gap: 6px;
+        align-items: center;
+      }
+
+      .mini-file-label {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 16px;
+        border-radius: 6px;
+        background: rgba(255, 255, 255, 0.09);
+        color: #ecf5ff;
+        font-size: 9px;
+        font-weight: 800;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+      }
+
+      .mini-file {
+        height: 6px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.08);
+        overflow: hidden;
+      }
+
+      .mini-file > span {
+        display: block;
+        height: 100%;
+        width: 100%;
+      }
+
+      .mini-file.uploaded > span {
+        background: linear-gradient(90deg, var(--success), var(--success-deep));
+      }
+
+      .mini-file.active > span {
+        background: linear-gradient(90deg, #ffffff, #91c4ff);
+      }
+
+      .mini-file.queued > span {
+        background: linear-gradient(90deg, rgba(94, 162, 255, 0.85), rgba(94, 162, 255, 0.55));
+      }
+
+      .mini-file.missing > span {
+        background: rgba(255, 255, 255, 0.08);
+      }
+
+      .incident-footer {
+        margin-top: 12px;
+        display: grid;
+        gap: 8px;
+      }
+
+      .inline-label {
+        color: var(--muted-2);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 11px;
+      }
+
+      .inline-value {
+        color: var(--muted);
+      }
+
+      .route-details {
+        margin-top: 18px;
+        border-radius: 18px;
+        background: rgba(255, 255, 255, 0.02);
+        border: 1px solid rgba(255, 255, 255, 0.05);
+        overflow: hidden;
+      }
+
+      .route-details summary {
+        list-style: none;
+        cursor: pointer;
+        padding: 14px 16px;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        align-items: center;
+      }
+
+      .route-details summary::-webkit-details-marker {
+        display: none;
+      }
+
+      .summary-copy strong {
+        display: block;
+        font-size: 16px;
+        margin-bottom: 2px;
+      }
+
+      .summary-copy span {
+        color: var(--muted);
+      }
+
+      .summary-toggle {
+        color: var(--muted);
+        white-space: nowrap;
+      }
+
+      .details-body {
+        padding: 0 16px 16px;
+      }
+
+      .legend {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-bottom: 12px;
+      }
+
+      .route-list {
+        display: grid;
+        gap: 12px;
+      }
+
+      .route-card {
+        padding: 14px;
+        border-radius: 16px;
+        background: var(--panel-3);
+        border: 1px solid rgba(255, 255, 255, 0.05);
+      }
+
+      .route-head {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        align-items: flex-start;
+        margin-bottom: 10px;
+      }
+
+      .route-id {
+        font-weight: 730;
+      }
+
+      .route-time {
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      .route-tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-bottom: 10px;
+      }
+
+      .timeline-shell {
+        position: relative;
+        overflow: hidden;
+        padding-bottom: 6px;
+      }
+
+      .timeline-shell::before,
+      .timeline-shell::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 24px;
+        pointer-events: none;
+        z-index: 1;
+      }
+
+      .timeline-shell::before {
+        left: 0;
+        background: linear-gradient(90deg, rgba(9, 16, 23, 0.92), rgba(9, 16, 23, 0));
+      }
+
+      .timeline-shell::after {
+        right: 0;
+        background: linear-gradient(270deg, rgba(9, 16, 23, 0.92), rgba(9, 16, 23, 0));
+      }
+
+      .timeline-wrap {
+        overflow-x: auto;
+        overflow-y: hidden;
+        padding: 2px 28px 20px 0;
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+      }
+
+      .timeline-wrap::-webkit-scrollbar {
+        display: none;
+        width: 0;
+        height: 0;
+      }
+
+      .timeline {
+        display: grid;
+        grid-auto-flow: column;
+        grid-auto-columns: 20px;
+        gap: 5px;
+        min-height: 88px;
+        align-items: end;
+      }
+
+      .segment {
+        position: relative;
+        width: 20px;
+        height: 42px;
+        border-radius: 9px;
+        background: rgba(255, 255, 255, 0.06);
+        border: 1px solid rgba(255, 255, 255, 0.05);
+        opacity: 0.34;
+        transition: opacity 120ms ease, transform 120ms ease;
+      }
+
+      .segment.lowq {
+        background: linear-gradient(180deg, rgba(48, 93, 165, 0.92), rgba(27, 54, 99, 0.96));
+        opacity: 0.7;
+      }
+
+      .segment.hq {
+        background: linear-gradient(180deg, rgba(49, 191, 122, 0.96), rgba(31, 127, 83, 0.98));
+        opacity: 0.96;
+      }
+
+      .segment.queued {
+        background-image:
+          repeating-linear-gradient(
+            -45deg,
+            rgba(255, 255, 255, 0.16) 0 4px,
+            transparent 4px 8px
+          );
+        opacity: 0.88;
+      }
+
+      .segment.active {
+        opacity: 1;
+        box-shadow:
+          0 0 0 1px rgba(255, 255, 255, 0.18),
+          0 0 18px rgba(255, 255, 255, 0.26);
+      }
+
+      .segment.phase-target {
+        transform: translateY(-2px);
+      }
+
+      .segment.bookmark,
+      .segment.alert,
+      .segment.dm-alert,
+      .segment.active,
+      .segment.queued,
+      .segment.hq {
+        opacity: 1;
+      }
+
+      .segment::before,
+      .segment::after {
+        content: "";
+        position: absolute;
+        left: 2px;
+        right: 2px;
+        border-radius: 999px;
+      }
+
+      .segment.bookmark::before {
+        top: 2px;
+        height: 4px;
+        background: var(--bookmark);
+      }
+
+      .segment.alert::after {
+        bottom: 2px;
+        height: 4px;
+        background: var(--alert);
+      }
+
+      .segment.dm-alert::after {
+        bottom: 2px;
+        height: 4px;
+        background: var(--dm);
+      }
+
+      .segment-label {
+        position: absolute;
+        left: 50%;
+        bottom: -20px;
+        transform: translateX(-50%);
+        font-size: 11px;
+        font-weight: 600;
+        color: #cfe0f3;
+        text-shadow: 0 1px 0 rgba(0, 0, 0, 0.35);
+      }
+
+      .queue-card {
+        padding: 18px;
+        display: grid;
+        gap: 14px;
+        align-content: start;
+      }
+
+      .queue-summary {
+        display: grid;
+        gap: 6px;
+        padding: 12px 14px;
+        border-radius: 16px;
+        background: var(--panel-2);
+        border: 1px solid rgba(255, 255, 255, 0.06);
+      }
+
+      .queue-summary-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 10px;
+      }
+
+      .queue-group-list {
+        display: grid;
+        gap: 12px;
+      }
+
+      .queue-group {
+        display: grid;
+        gap: 8px;
+      }
+
+      .queue-group-head {
+        display: flex;
+        justify-content: space-between;
+        gap: 10px;
+        align-items: baseline;
+      }
+
+      .queue-group-title {
+        font-weight: 700;
+      }
+
+      .queue-group-subtitle {
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      .queue-list {
+        display: grid;
+        gap: 8px;
+      }
+
+      .queue-item {
+        padding: 12px;
+        border-radius: 14px;
+        background: var(--panel-2);
+        border: 1px solid rgba(255, 255, 255, 0.05);
+      }
+
+      .queue-item.current {
+        border-color: rgba(94, 162, 255, 0.28);
+        box-shadow: 0 0 0 1px rgba(94, 162, 255, 0.12);
+      }
+
+      .queue-primary {
+        display: flex;
+        justify-content: space-between;
+        gap: 10px;
+        align-items: baseline;
+      }
+
+      .queue-main {
+        font-weight: 700;
+      }
+
+      .queue-meta {
+        margin-top: 4px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      .queue-path {
+        margin-top: 6px;
+        color: var(--muted-2);
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: 11px;
+        overflow-wrap: anywhere;
+      }
+
+      .progress {
+        margin-top: 8px;
+        height: 7px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.08);
+        overflow: hidden;
+      }
+
+      .progress > span {
+        display: block;
+        height: 100%;
+        background: linear-gradient(90deg, rgba(255, 255, 255, 0.9), rgba(94, 162, 255, 0.94));
+      }
+
+      .empty {
+        padding: 18px;
+        color: var(--muted);
+        border-radius: 16px;
+        background: rgba(255, 255, 255, 0.025);
+        border: 1px dashed rgba(255, 255, 255, 0.08);
+      }
+
+      .status-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 999px;
+        display: inline-block;
+      }
+
+      .status-dot.uploaded {
+        background: linear-gradient(180deg, var(--success), var(--success-deep));
+      }
+
+      .status-dot.active {
+        background: linear-gradient(180deg, #ffffff, #91c4ff);
+      }
+
+      .status-dot.queued {
+        background: linear-gradient(180deg, rgba(94, 162, 255, 0.92), rgba(94, 162, 255, 0.58));
+      }
+
+      .status-dot.missing {
+        background: rgba(255, 255, 255, 0.18);
+      }
+
+      @media (max-width: 1220px) {
+        .layout {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      @media (max-width: 980px) {
+        .overview {
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+        }
+
+        .incident-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      @media (max-width: 720px) {
+        .shell {
+          padding: 14px 14px 22px;
+        }
+
+        .hero {
+          flex-direction: column;
+        }
+
+        .overview {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+
+        .device-head,
+        .phase-banner,
+        .queue-primary,
+        .queue-group-head,
+        .route-head,
+        .section-head {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .device-status {
+          justify-items: start;
+          text-align: left;
+        }
+      }
+
+      @media (max-width: 560px) {
+        .overview {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="shell">
+      <header class="hero">
+        <div>
+          <h1>Comma Watch Dashboard</h1>
+          <p>
+            Watch what is becoming clip-usable next, what Athena is actively uploading for it, and how far the
+            watcher has gotten before route-fill takes over.
+          </p>
+        </div>
+        <div class="stamp" id="stamp">Loading…</div>
+      </header>
+
+      <section class="overview" id="overview"></section>
+
+      <div class="layout">
+        <main id="devices" class="stack"></main>
+        <aside class="queue-card card">
+          <div>
+            <h2>Queue With Reasons</h2>
+          </div>
+          <div id="queue-summary"></div>
+          <div id="queue"></div>
+        </aside>
+      </div>
+    </div>
+
+    <script>
+      const byId = (id) => document.getElementById(id);
+
+      function fmtTime(value) {
+        if (!value) return "unknown";
+        try {
+          return new Date(value).toLocaleString();
+        } catch {
+          return String(value);
+        }
+      }
+
+      function pct(value) {
+        return `${Math.round((value || 0) * 100)}%`;
+      }
+
+      function titleCase(value) {
+        return String(value || "")
+          .replaceAll("_", " ")
+          .replace(/\b\w/g, (match) => match.toUpperCase());
+      }
+
+      function categoryLabel(category) {
+        if (category === "dm_alert") return "DM Alert";
+        if (category === "bookmark") return "Bookmark";
+        if (category === "alert") return "Alert";
+        return titleCase(category);
+      }
+
+      function categoryClass(category) {
+        if (category === "dm_alert") return "dm-alert";
+        if (category === "alert") return "alert";
+        return "bookmark";
+      }
+
+      function queueReasonLabel(item) {
+        return item.reason_label || "unclassified";
+      }
+
+      function fileKindLabel(kind) {
+        const labels = {
+          fcamera: "Fwd",
+          rlog: "Log",
+          ecamera: "Wide",
+          dcamera: "Drv",
+        };
+        return labels[kind] || titleCase(kind);
+      }
+
+      function buildOverview(state) {
+        const devices = state.devices || [];
+        const queueItems = devices.flatMap((device) => device.queue?.items || []);
+        const incidentWindows = devices.flatMap((device) => device.incident_windows || []);
+        const activeItems = queueItems.filter((item) => item.current);
+        const activeWindows = incidentWindows.filter((window) => window.is_active_phase_window);
+        return [
+          ["Devices Online", String(devices.length)],
+          ["Incident Windows", String(incidentWindows.length)],
+          ["Queue Length", String(queueItems.length)],
+          ["Active Uploads", String(activeItems.length)],
+          ["Windows In Flight", String(activeWindows.length)],
+          ["Generated", fmtTime(state.generated_at)],
+        ];
+      }
+
+      function renderOverview(state) {
+        const root = byId("overview");
+        root.innerHTML = "";
+        for (const [label, value] of buildOverview(state)) {
+          const card = document.createElement("div");
+          card.className = "metric";
+          card.innerHTML = `<div class="metric-label">${label}</div><div class="metric-value">${value}</div>`;
+          root.appendChild(card);
+        }
+      }
+
+      function segmentPillClass(status) {
+        if (status.is_complete) return "segment-pill complete";
+        if ((status.active_file_kinds || []).length) return "segment-pill active";
+        if ((status.queued_file_kinds || []).length) return "segment-pill queued";
+        return "segment-pill";
+      }
+
+      function miniFileState(status, kind) {
+        if ((status.uploaded_file_kinds || []).includes(kind)) return "uploaded";
+        if ((status.active_file_kinds || []).includes(kind)) return "active";
+        if ((status.queued_file_kinds || []).includes(kind)) return "queued";
+        return "missing";
+      }
+
+      function incidentStatusLine(window) {
+        const completion = window.completion || {};
+        const totalSegments = (window.segment_order || []).length;
+        const completeSegments = (window.segment_statuses || []).filter((status) => status.is_complete).length;
+        return `segment ${window.anchor_segment} window • ${completeSegments}/${totalSegments} segments complete • ${completion.missing || 0} files still missing`;
+      }
+
+      function incidentFooterLine(window) {
+        const first = window.first_incomplete_segment;
+        if (window.ready_state === "complete" && String(window.phase_membership || "").startsWith("bookmark_fill")) {
+          return "Core clip ready; filling outward";
+        }
+        if (window.ready_state === "complete") {
+          return "Clip-ready window complete";
+        }
+        if (!first) {
+          return "Waiting for queue activity";
+        }
+        const active = first.active_file_kinds?.length ? `active ${first.active_file_kinds.join(", ")}` : null;
+        const queued = first.queued_file_kinds?.length ? `queued ${first.queued_file_kinds.join(", ")}` : null;
+        const missing = first.missing_file_kinds?.length ? `missing ${first.missing_file_kinds.join(", ")}` : null;
+        return `Next up: seg ${first.segment} • ${[active, queued, missing].filter(Boolean).join(" • ")}`;
+      }
+
+      function renderIncidentCard(window) {
+        const card = document.createElement("section");
+        card.className = `incident-card ${window.is_active_phase_window ? "active-window" : ""}`;
+
+        const chips = [
+          `<span class="chip ${categoryClass(window.category)}">${categoryLabel(window.category)}</span>`,
+          `<span class="chip phase">${titleCase(window.phase_membership || "none")}</span>`,
+          `<span class="chip neutral">${titleCase(window.ready_state)}</span>`,
+        ];
+
+        const segmentPills = (window.segment_statuses || [])
+          .map((status, index) => `<span class="${segmentPillClass(status)}">#${status.segment}</span>`)
+          .join("");
+
+        const strip = (window.segment_statuses || [])
+          .map((status, index) => {
+            const files = (window.required_file_order || [])
+              .map(
+                (kind) => `
+                  <div class="mini-file-row">
+                    <span class="mini-file-label">${fileKindLabel(kind)}</span>
+                    <div class="mini-file ${miniFileState(status, kind)}"><span></span></div>
+                  </div>
+                `,
+              )
+              .join("");
+            return `
+              <div class="incident-segment ${status.is_complete ? "complete" : ""} ${
+              (status.active_file_kinds || []).length ? "active" : ""
+            }">
+                <div class="incident-segment-header">
+                  <strong>Seg ${status.segment}</strong>
+                  <span class="incident-segment-rank">${index + 1}</span>
+                </div>
+                <div class="mini-files">${files}</div>
+              </div>
+            `;
+          })
+          .join("");
+
+        const uploading = (window.currently_uploading_files || []).length
+          ? `<div><div class="inline-label">Now Uploading</div><div class="file-chip-row">${window.currently_uploading_files
+              .map((file) => `<span class="chip neutral">seg ${file.segment} ${file.file_kind}</span>`)
+              .join("")}</div></div>`
+          : "";
+
+        card.innerHTML = `
+          <div class="incident-top">
+            <div>
+              <div class="incident-route">${window.route_id}</div>
+              <div class="incident-time">${fmtTime(window.route_start_time)}</div>
+            </div>
+            <div class="chip-row">${chips.join("")}</div>
+          </div>
+          <div class="incident-status">${incidentStatusLine(window)}</div>
+          <div class="segment-pill-row">${segmentPills}</div>
+          <div class="incident-strip">${strip}</div>
+          <div class="incident-footer">
+            ${uploading}
+            <div>
+              <div class="inline-label">Next Up</div>
+              <div class="inline-value">${incidentFooterLine(window)}</div>
+            </div>
+          </div>
+        `;
+        return card;
+      }
+
+      function renderIncidentExplainer() {
+        const wrapper = document.createElement("div");
+        wrapper.className = "incident-explainer";
+        wrapper.innerHTML = `
+          <div class="incident-explainer-copy">
+            Each segment card shows the exact files needed to make that minute clip-usable. Every row is one file:
+            forward camera, route log, wide camera, and driver camera.
+          </div>
+          <div class="file-key">
+            <span class="key-chip"><strong>Fwd</strong> forward camera</span>
+            <span class="key-chip"><strong>Log</strong> route logs</span>
+            <span class="key-chip"><strong>Wide</strong> wide road camera</span>
+            <span class="key-chip"><strong>Drv</strong> driver camera</span>
+          </div>
+          <div class="status-key">
+            <span class="key-chip"><span class="status-dot uploaded"></span> uploaded</span>
+            <span class="key-chip"><span class="status-dot active"></span> uploading now</span>
+            <span class="key-chip"><span class="status-dot queued"></span> queued</span>
+            <span class="key-chip"><span class="status-dot missing"></span> still missing</span>
+          </div>
+        `;
+        return wrapper;
+      }
+
+      function segmentClass(segment) {
+        const files = segment.files || {};
+        const hasHQ = files.fcamera && files.rlog && files.ecamera && files.dcamera;
+        const hasLowQ = files.qcamera || files.qlog;
+        const classes = ["segment"];
+        if (hasHQ) classes.push("hq");
+        else if (hasLowQ) classes.push("lowq");
+        if (segment.queued_count) classes.push("queued");
+        if (segment.active_count) classes.push("active");
+        if (segment.active_phase_rank) classes.push("phase-target");
+        if (segment.bookmark) classes.push("bookmark");
+        if (segment.dm_alert) classes.push("dm-alert");
+        else if (segment.alert) classes.push("alert");
+        return classes.join(" ");
+      }
+
+      function segmentTitle(route, segment) {
+        const files = segment.files || {};
+        const available = Object.entries(files)
+          .filter(([, present]) => present)
+          .map(([name]) => name);
+        return [
+          `${route.route_id} seg ${segment.segment}`,
+          `bookmark=${segment.bookmark} dm=${segment.dm_alert} alert=${segment.alert}`,
+          `phase=${segment.phase || "none"} rank=${segment.phase_rank || "-"}`,
+          `available=${available.join(", ") || "none"}`,
+          `queued=${(segment.queued_file_kinds || []).join(", ") || "none"}`,
+          `active=${(segment.active_file_kinds || []).join(", ") || "none"}`,
+        ].join("\n");
+      }
+
+      function routeSummary(device) {
+        const routes = device.routes || [];
+        const bookmarkRoutes = routes.filter((route) => (route.bookmark_segments || []).length).length;
+        const alertRoutes = routes.filter((route) => (route.alert_segments || []).length || (route.dm_alert_segments || []).length).length;
+        return `${routes.length} routes in window • ${bookmarkRoutes} routes with bookmarks • ${alertRoutes} routes with alerts`;
+      }
+
+      function renderRoutes(device) {
+        const routes = [...(device.routes || [])].sort((a, b) => (a.start_time < b.start_time ? 1 : -1));
+        const details = document.createElement("details");
+        details.className = "route-details";
+
+        const summary = document.createElement("summary");
+        summary.innerHTML = `
+          <div class="summary-copy">
+            <strong>Route Timelines</strong>
+            <span>${routeSummary(device)}</span>
+          </div>
+          <div class="summary-toggle">Show route timelines</div>
+        `;
+        details.appendChild(summary);
+
+        details.addEventListener("toggle", () => {
+          const toggle = summary.querySelector(".summary-toggle");
+          if (toggle) toggle.textContent = details.open ? "Hide route timelines" : "Show route timelines";
+        });
+
+        const body = document.createElement("div");
+        body.className = "details-body";
+        body.innerHTML = `
+          <div class="legend">
+            <span class="chip neutral">Each big pill = one 60-second segment</span>
+            <span class="chip bookmark">Bookmark</span>
+            <span class="chip dm-alert">DM Alert</span>
+            <span class="chip alert">Alert</span>
+            <span class="chip neutral">Blue = low quality present</span>
+            <span class="chip neutral">Green = clip-ready HQ bundle</span>
+            <span class="chip neutral">Glow = actively uploading</span>
+          </div>
+        `;
+
+        const list = document.createElement("div");
+        list.className = "route-list";
+        for (const route of routes) {
+          const routeCard = document.createElement("section");
+          routeCard.className = "route-card";
+
+          const tags = [];
+          if ((route.bookmark_segments || []).length) tags.push(`<span class="chip bookmark">Bookmarks ${route.bookmark_segments.join(", ")}</span>`);
+          if ((route.dm_alert_segments || []).length) tags.push(`<span class="chip dm-alert">DM ${route.dm_alert_segments.join(", ")}</span>`);
+          if ((route.alert_segments || []).length) tags.push(`<span class="chip alert">Alerts ${route.alert_segments.join(", ")}</span>`);
+          tags.push(`<span class="chip neutral">maxqlog ${route.maxqlog}</span>`);
+          tags.push(`<span class="chip neutral">procqlog ${route.procqlog ?? "?"}</span>`);
+
+          const timeline = document.createElement("div");
+          timeline.className = "timeline";
+          for (const segment of route.segments || []) {
+            const segEl = document.createElement("div");
+            segEl.className = segmentClass(segment);
+            segEl.title = segmentTitle(route, segment);
+            if (segment.segment % 5 === 0 || segment.bookmark || segment.alert || segment.dm_alert || segment.active_count) {
+              const label = document.createElement("div");
+              label.className = "segment-label";
+              label.textContent = String(segment.segment);
+              segEl.appendChild(label);
+            }
+            timeline.appendChild(segEl);
+          }
+
+          routeCard.innerHTML = `
+            <div class="route-head">
+              <div>
+                <div class="route-id">${route.route_id}</div>
+                <div class="route-time">${fmtTime(route.start_time)}</div>
+              </div>
+              <div class="route-time">${(route.segments || []).length} segments</div>
+            </div>
+            <div class="route-tags">${tags.join("")}</div>
+          `;
+
+          const timelineShell = document.createElement("div");
+          timelineShell.className = "timeline-shell";
+          const scroll = document.createElement("div");
+          scroll.className = "timeline-wrap";
+          scroll.appendChild(timeline);
+          timelineShell.appendChild(scroll);
+          routeCard.appendChild(timelineShell);
+          list.appendChild(routeCard);
+        }
+
+        body.appendChild(list);
+        details.appendChild(body);
+        return details;
+      }
+
+      function renderDevices(state) {
+        const root = byId("devices");
+        root.innerHTML = "";
+        const devices = state.devices || [];
+        if (!devices.length) {
+          root.innerHTML = `<section class="device-card card"><div class="empty">No online devices in the current watcher snapshot.</div></section>`;
+          return;
+        }
+
+        for (const device of devices) {
+          const card = document.createElement("section");
+          card.className = "device-card card";
+          const incidents = (device.incident_windows || []).slice(0, 6);
+          const activePhase = device.active_phase;
+          const activeWindows = (device.incident_windows || []).filter((window) => window.is_active_phase_window);
+
+          card.innerHTML = `
+            <div class="device-head">
+              <div>
+                <div class="device-name">${device.alias || device.dongle_id}</div>
+                <div class="device-meta">${device.dongle_id}</div>
+              </div>
+              <div class="device-status">
+                <span>queue ${device.queue?.length || 0} · active ${device.queue?.active_length || 0}</span>
+                <span>${(device.incident_windows || []).length} incident windows tracked</span>
+              </div>
+            </div>
+            <div class="phase-banner">
+              <div>
+                <div class="phase-title">Watcher Focus</div>
+                <div class="phase-name">${titleCase(activePhase?.name || "idle")}</div>
+                <div class="phase-summary">${
+                  activeWindows.length
+                    ? `${activeWindows.length} incident window(s) actively being serviced`
+                    : "No active incident window right now"
+                }</div>
+              </div>
+              <div class="phase-count">${activePhase?.targets?.length || 0} target segments</div>
+            </div>
+          `;
+
+          const sectionHead = document.createElement("div");
+          sectionHead.className = "section-head";
+          sectionHead.innerHTML = `
+            <h2>Now Becoming Usable</h2>
+            <div class="section-note">Top incident windows in watcher priority order</div>
+          `;
+          card.appendChild(sectionHead);
+
+          if (!incidents.length) {
+            const empty = document.createElement("div");
+            empty.className = "empty";
+            empty.textContent = "No bookmark or alert windows are visible right now.";
+            card.appendChild(empty);
+          } else {
+            card.appendChild(renderIncidentExplainer());
+            const grid = document.createElement("div");
+            grid.className = "incident-grid";
+            for (const incident of incidents) grid.appendChild(renderIncidentCard(incident));
+            card.appendChild(grid);
+          }
+
+          card.appendChild(renderRoutes(device));
+          root.appendChild(card);
+        }
+      }
+
+      function sortQueueItems(items) {
+        return [...items].sort((a, b) => {
+          if (a.current !== b.current) return a.current ? -1 : 1;
+          const aSeg = a.segment_rank_within_window ?? 999;
+          const bSeg = b.segment_rank_within_window ?? 999;
+          if (aSeg !== bSeg) return aSeg - bSeg;
+          const aFile = a.file_rank_within_segment ?? 999;
+          const bFile = b.file_rank_within_segment ?? 999;
+          if (aFile !== bFile) return aFile - bFile;
+          return String(a.path).localeCompare(String(b.path));
+        });
+      }
+
+      function renderQueue(state) {
+        const summaryRoot = byId("queue-summary");
+        const queueRoot = byId("queue");
+        summaryRoot.innerHTML = "";
+        queueRoot.innerHTML = "";
+
+        const devices = state.devices || [];
+        const queueItems = devices.flatMap((device) => device.queue?.items || []);
+        const activeItems = queueItems.filter((item) => item.current);
+        const activePhase = devices.map((device) => device.active_phase?.name).find(Boolean) || "idle";
+        const incidentWindows = devices.flatMap((device) => device.incident_windows || []);
+        const activeWindows = incidentWindows.filter((window) => window.is_active_phase_window);
+
+        summaryRoot.innerHTML = `
+          <div class="queue-summary">
+            <div class="phase-title">Queue Summary</div>
+            <div class="phase-name">${titleCase(activePhase)}</div>
+            <div class="queue-summary-grid">
+              <div>
+                <div class="metric-label">Active uploads</div>
+                <div class="metric-value">${activeItems.length}</div>
+              </div>
+              <div>
+                <div class="metric-label">Windows in service</div>
+                <div class="metric-value">${activeWindows.length}</div>
+              </div>
+            </div>
+            <div class="section-note">${
+              activeWindows.length
+                ? activeWindows.slice(0, 3).map((window) => `${window.route_id} seg ${window.anchor_segment}`).join(" • ")
+                : "No active incident windows right now"
+            }</div>
+          </div>
+        `;
+
+        if (!queueItems.length) {
+          queueRoot.innerHTML = `<div class="empty">Nothing queued right now.</div>`;
+          return;
+        }
+
+        const grouped = new Map();
+        const sorted = sortQueueItems(queueItems).slice(0, 24);
+        for (const item of sorted) {
+          const groupKey = item.incident_window_id || `fallback:${queueReasonLabel(item)}`;
+          if (!grouped.has(groupKey)) grouped.set(groupKey, []);
+          grouped.get(groupKey).push(item);
+        }
+
+        const incidentsById = new Map(incidentWindows.map((window) => [window.id, window]));
+        const list = document.createElement("div");
+        list.className = "queue-group-list";
+
+        for (const [groupKey, items] of grouped.entries()) {
+          const first = items[0];
+          const incident = first.incident_window_id ? incidentsById.get(first.incident_window_id) : null;
+          const section = document.createElement("section");
+          section.className = "queue-group";
+          section.innerHTML = `
+            <div class="queue-group-head">
+              <div>
+                <div class="queue-group-title">${
+                  incident ? `${categoryLabel(incident.category)} • ${incident.route_id} • seg ${incident.anchor_segment}` : titleCase(queueReasonLabel(first))
+                }</div>
+                <div class="queue-group-subtitle">${
+                  incident
+                    ? `${titleCase(incident.phase_membership)} • ${titleCase(incident.ready_state)}`
+                    : first.reason_label
+                      ? titleCase(first.reason_label)
+                      : "Queue item"
+                }</div>
+              </div>
+              <div class="queue-group-subtitle">${items.length} file(s)</div>
+            </div>
+          `;
+
+          const queueList = document.createElement("div");
+          queueList.className = "queue-list";
+          for (const item of items) {
+            const entry = document.createElement("article");
+            entry.className = `queue-item ${item.current ? "current" : ""}`;
+            entry.innerHTML = `
+              <div class="queue-primary">
+                <div class="queue-main">${item.route_id} • seg ${item.segment} • ${item.file_kind || item.filename}</div>
+                <div class="queue-group-subtitle">${item.current ? "active" : "queued"} • ${pct(item.progress)}</div>
+              </div>
+              <div class="queue-meta">
+                <span>${titleCase(queueReasonLabel(item))}</span>
+                ${item.segment_rank_within_window ? `<span>segment rank ${item.segment_rank_within_window}</span>` : ""}
+                ${item.file_rank_within_segment ? `<span>file rank ${item.file_rank_within_segment}</span>` : ""}
+                <span>retry ${item.retry_count}</span>
+              </div>
+              <div class="queue-path">${item.path}</div>
+              <div class="progress"><span style="width:${Math.max(3, Math.round((item.progress || 0) * 100))}%"></span></div>
+            `;
+            queueList.appendChild(entry);
+          }
+          section.appendChild(queueList);
+          list.appendChild(section);
+        }
+
+        queueRoot.appendChild(list);
+      }
+
+      async function load() {
+        const response = await fetch(`/state?ts=${Date.now()}`, { cache: "no-store" });
+        const state = await response.json();
+        byId("stamp").textContent = state.generated_at ? `Snapshot ${fmtTime(state.generated_at)}` : "Waiting for watcher state…";
+        renderOverview(state);
+        renderDevices(state);
+        renderQueue(state);
+      }
+
+      load().catch((error) => {
+        byId("stamp").textContent = `Failed to load state: ${error}`;
+      });
+      setInterval(() => load().catch(() => {}), 4000);
+    </script>
+  </body>
+</html>

--- a/tools/comma_watch_dashboard.py
+++ b/tools/comma_watch_dashboard.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+DEFAULT_STATE_PATH = "/tmp/comma-watch-state.json"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Local dashboard for the Comma watcher.")
+    parser.add_argument("--host", default="127.0.0.1", help="Host to bind the local dashboard server.")
+    parser.add_argument("--port", type=int, default=8765, help="Port to bind the local dashboard server.")
+    parser.add_argument("--state-path", default=DEFAULT_STATE_PATH, help="Watcher JSON state snapshot path.")
+    return parser.parse_args()
+
+
+def load_html() -> bytes:
+    html_path = Path(__file__).with_name("comma_watch_dashboard.html")
+    return html_path.read_bytes()
+
+
+def load_state(state_path: Path) -> bytes:
+    if not state_path.exists():
+        return json.dumps(
+            {
+                "generated_at": None,
+                "window_start": None,
+                "devices": [],
+                "message": "Waiting for watcher state...",
+            }
+        ).encode("utf-8")
+    return state_path.read_bytes()
+
+
+def make_handler(*, html: bytes, state_path: Path) -> type[BaseHTTPRequestHandler]:
+    class DashboardHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            if self.path in {"/", "/index.html"}:
+                self._send_bytes(HTTPStatus.OK, html, "text/html; charset=utf-8")
+                return
+            if self.path.startswith("/state"):
+                self._send_bytes(HTTPStatus.OK, load_state(state_path), "application/json; charset=utf-8")
+                return
+            if self.path == "/health":
+                self._send_bytes(HTTPStatus.OK, b"ok\n", "text/plain; charset=utf-8")
+                return
+            self._send_bytes(HTTPStatus.NOT_FOUND, b"not found\n", "text/plain; charset=utf-8")
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+            return
+
+        def _send_bytes(self, status: HTTPStatus, body: bytes, content_type: str) -> None:
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    return DashboardHandler
+
+
+def main() -> int:
+    args = parse_args()
+    html = load_html()
+    state_path = Path(args.state_path)
+    handler = make_handler(html=html, state_path=state_path)
+    server = ThreadingHTTPServer((args.host, args.port), handler)
+    print(f"Watcher dashboard: http://{args.host}:{args.port}")
+    print(f"Reading watcher state from {state_path}")
+    server.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Prefer GitHub route-source history when resolving the rendered overlay model commit
- Keep local git resolution as an offline fallback
- Add a regression test for stale local checkout metadata returning `61f7c7ea` instead of route-correct `4988a62b`

## Root cause
The renderer checked the local openpilot checkout before GitHub. In hosted/shallow/current checkouts, that local history can describe the renderer image checkout rather than the route source commit, causing the overlay to show the wrong model commit.

## Validation
- `uv run pytest -q tests/test_big_ui_engine.py`